### PR TITLE
Update GitHub Actions workflow to use GHP_TOKEN instead of GITHUB_TOK…

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -35,5 +35,5 @@ jobs:
         with:
           args: --release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GHP_TOKEN }}
           ASSET_PATH: ./dist


### PR DESCRIPTION
…EN for enhanced security.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the authentication method used in the release workflow for improved token management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->