### PR TITLE
Release v0.5.62

### DIFF
--- a/docs/CLOUD_SYNC.md
+++ b/docs/CLOUD_SYNC.md
@@ -162,7 +162,7 @@ configStore.onDidChange('pages', async (newValue, oldValue) => {
 
 ```http
 GET /api/users/settings HTTP/1.1
-Host: app.toast.sh
+Host: toast.sh
 Authorization: Bearer ACCESS_TOKEN
 ```
 
@@ -184,7 +184,7 @@ Authorization: Bearer ACCESS_TOKEN
 
 ```http
 PUT /api/users/settings HTTP/1.1
-Host: app.toast.sh
+Host: toast.sh
 Authorization: Bearer ACCESS_TOKEN
 Content-Type: application/json
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "toast-app",
-  "version": "0.5.61",
+  "version": "0.5.62",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "toast-app",
-      "version": "0.5.61",
+      "version": "0.5.62",
       "license": "MIT",
       "dependencies": {
         "@nut-tree-fork/nut-js": "^4.2.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "toast-app",
-  "version": "0.5.61",
+  "version": "0.5.62",
   "description": "A customizable shortcut launcher for macOS and Windows",
   "author": "nalbam <me@nalbam.com>",
   "license": "MIT",

--- a/src/main/api/client.js
+++ b/src/main/api/client.js
@@ -9,7 +9,7 @@ const { getEnv } = require('../config/env');
 const { DEFAULT_ANONYMOUS_SUBSCRIPTION } = require('../constants');
 
 // Base URL and endpoint configuration
-const TOAST_URL = getEnv('TOAST_URL', 'https://app.toast.sh');
+const TOAST_URL = getEnv('TOAST_URL', 'https://toast.sh');
 const API_BASE_URL = `${TOAST_URL}/api`;
 
 // API endpoints

--- a/src/main/config/.env.example
+++ b/src/main/config/.env.example
@@ -2,7 +2,7 @@
 CLIENT_ID=
 CLIENT_SECRET=
 
-TOAST_URL="https://app.toast.sh"
+TOAST_URL="https://toast.sh"
 
 # 토큰 만료 시간(초) 설정
 # - 2592000은 30일 (기본 설정)

--- a/src/main/constants.js
+++ b/src/main/constants.js
@@ -7,7 +7,7 @@
 // 앱 기본 정보 (package.json 정보를 읽을 수 없을 때 사용)
 const APP_DEFAULT_INFO = {
   author: 'nalbam <me@nalbam.com>, bruce <bruce@daangn.com>',
-  homepage: 'https://app.toast.sh',
+  homepage: 'https://toast.sh',
   description: 'A customizable shortcut launcher for macOS and Windows',
   license: 'MIT',
   version: 'v0.0.0', // 버전을 가져오지 못할 때 기본값
@@ -46,7 +46,7 @@ const DEFAULT_ANONYMOUS = {
   id: 'anonymous',
   email: 'anonymous@user.com',
   name: 'Guest User',
-  image: 'https://app.toast.sh/logo192.png',
+  image: 'https://toast.sh/logo192.png',
   slug: 'guest',
   is_authenticated: false,
   created_at: new Date().toISOString(),

--- a/src/renderer/pages/settings/index.js
+++ b/src/renderer/pages/settings/index.js
@@ -490,7 +490,7 @@ function setupEventListeners() {
   // About 탭 관련 버튼
   if (homepageButton) {
     homepageButton.addEventListener('click', () => {
-      window.settings.openUrl('https://app.toast.sh');
+      window.settings.openUrl('https://toast.sh');
     });
   }
 
@@ -1475,7 +1475,7 @@ function confirmCancel() {
  */
 function handleManageSubscription() {
   window.settings.log.info('구독 관리 페이지 열기');
-  window.settings.openUrl('https://app.toast.sh/subscription');
+  window.settings.openUrl('https://toast.sh/subscription');
 }
 
 /**

--- a/src/renderer/pages/toast/index.js
+++ b/src/renderer/pages/toast/index.js
@@ -3,7 +3,7 @@
  */
 
 // Toast URL configuration
-const TOAST_URL = window.toast?.apiBaseUrl || 'https://app.toast.sh';
+const TOAST_URL = window.toast?.apiBaseUrl || 'https://toast.sh';
 const SUBSCRIPTION_URL = `${TOAST_URL}/subscription`;
 const DASHBOARD_URL = `${TOAST_URL}/dashboard`;
 
@@ -90,23 +90,23 @@ const defaultButtons = [
   {
     name: 'Toast',
     shortcut: 'Q',
-    icon: 'https://app.toast.sh/favicon.ico',
+    icon: 'https://toast.sh/favicon.ico',
     action: 'open',
-    url: 'https://app.toast.sh',
+    url: 'https://toast.sh',
   },
   {
     name: 'How to Use',
     shortcut: 'W',
     icon: 'FlatColorIcons.questions',
     action: 'open',
-    url: 'https://app.toast.sh/how-to-use',
+    url: 'https://toast.sh/how-to-use',
   },
   {
     name: 'Subscribe',
     shortcut: 'E',
     icon: 'FlatColorIcons.synchronize',
     action: 'open',
-    url: 'https://app.toast.sh/subscription',
+    url: 'https://toast.sh/subscription',
   },
   {
     name: 'Confetti',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated all references from "app.toast.sh" to "toast.sh" across the app, including API endpoints, environment variables, homepage links, subscription management, and icon sources.
  - Incremented the app version to 0.5.62.
- **Documentation**
  - Updated cloud sync API documentation to reflect the new "toast.sh" domain in example requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->