### PR TITLE
fix: resolve 14 bugs and security gaps found in a domain audit

### DIFF
--- a/docs/api/actions.md
+++ b/docs/api/actions.md
@@ -179,8 +179,8 @@ async function executeChainedActions(action)
 
 ```javascript
 {
-  success: true|false, // 전체 체인이 성공적으로 실행되었는지 여부
-  message: "Chain executed successfully" | "Chain execution stopped due to an error",
+  success: true|false, // 전체 체인이 성공적으로 실행되었는지 여부 (하나라도 실패하면 false)
+  message: "Chain executed successfully" | "Chain execution stopped due to an error" | "Chain completed with one or more errors",
   results: [
     {
       index: 0, // 체인에서 액션의 인덱스

--- a/docs/features/cloud-sync.md
+++ b/docs/features/cloud-sync.md
@@ -83,7 +83,7 @@ async function storeTokens(token, refreshToken, expiresIn = 31536000) {
     }
 
     // 토큰과 만료 시간을 함께 저장 (readTokenFile/writeTokenFile이
-    // safeStorage 암호화 여부를 투명하게 처리)
+    // 평문 JSON 파일 읽기/쓰기와 0600 권한 설정을 처리)
     const tokenData = readTokenFile() || {};
     tokenData[TOKEN_KEY] = token;
     if (refreshToken) {
@@ -121,7 +121,7 @@ TOKEN_EXPIRES_IN=86400  # 1일
 ### 토큰 관리 모범 사례
 
 1. **무기한 토큰 사용**: 동기화 중단 방지를 위해 토큰을 무기한으로 설정
-2. **로컬 파일 저장**: 토큰을 로컬 JSON 파일(`auth-tokens.json`)에 저장. `safeStorage`(OS 키체인/자격 증명 저장소)로 암호화되며, 이용 불가한 환경(예: 시크릿 서비스가 없는 일부 Linux)에서는 평문 + 0600 권한으로 대체됩니다. 암호화 이전에 저장된 레거시 평문 파일도 읽을 때 자동으로 인식되어 다음 저장 시 암호화됩니다(별도 마이그레이션 불필요).
+2. **로컬 파일 저장**: 토큰을 로컬 JSON 파일(`auth-tokens.json`)에 평문으로 저장하고, 소유자만 읽기/쓰기 가능한 권한(`0600`)으로 보호합니다. macOS Keychain 등 OS 보안 저장소는 사용하지 않습니다(자세한 내용은 [보안](../architecture/security.md#토큰-관리) 참조). 과거 `safeStorage`로 암호화되어 저장된 레거시 파일도 읽을 때 자동으로 인식되어 평문으로 마이그레이션됩니다.
 3. **원자적 쓰기**: 액세스·리프레시 토큰을 `storeTokens()` 한 번의 쓰기로 함께 저장(임시 파일 사용). 서버가 갱신할 때마다 리프레시 토큰을 회전시키므로, 두 토큰을 따로 저장하면 그 사이 크래시 시 이미 폐기된 리프레시 토큰만 남아 강제 재로그인이 발생할 수 있습니다.
 4. **오류 처리**: 토큰 관련 오류 시 적절한 로깅 및 복구 로직
 5. **로그아웃 시 서버 폐기**: 로그아웃 시 저장된 리프레시 토큰을 서버에 revoke 요청(`/oauth/revoke`)해 로컬 파일 삭제 후에도 서버에서 재사용되지 않도록 합니다.

--- a/src/main/action-approval.js
+++ b/src/main/action-approval.js
@@ -11,12 +11,59 @@
  */
 
 const crypto = require('crypto');
+const path = require('path');
 const { createLogger } = require('./logger');
 
 const logger = createLogger('ActionApproval');
 
 const MAX_TRUSTED_ACTIONS = 1000;
 const PREVIEW_LENGTH = 200;
+
+/**
+ * Directories Windows installers place executables under. A .exe launched
+ * from one of these is the Windows equivalent of a macOS .app bundle — it
+ * came from a normal install, not a script dropped in an arbitrary location.
+ * @returns {string[]} Existing trusted install directories
+ */
+function getWindowsTrustedInstallDirs() {
+  return [
+    process.env.ProgramFiles,
+    process.env['ProgramFiles(x86)'],
+    process.env.LOCALAPPDATA && path.win32.join(process.env.LOCALAPPDATA, 'Programs'),
+    process.env.WINDIR,
+  ].filter(Boolean);
+}
+
+/**
+ * Whether a parameterless application launch targets something that looks
+ * like a normal installed app rather than an arbitrary script or executable.
+ * macOS: an actual .app bundle. Windows: a .exe under a standard install
+ * directory (Program Files, per-user Programs, or the Windows directory).
+ * Other platforms have no equivalent convention, so nothing qualifies.
+ * @param {string} applicationPath - Application path to check
+ * @returns {boolean} Whether the launch stays gate-free without parameters
+ */
+function isTrustedAppLaunch(applicationPath) {
+  if (process.platform === 'darwin') {
+    return /\.app\/?$/i.test(applicationPath);
+  }
+
+  if (process.platform === 'win32') {
+    if (!/\.exe$/i.test(applicationPath)) {
+      return false;
+    }
+    // Use path.win32 explicitly rather than the platform-dependent path module,
+    // since this branch must parse Windows-style paths correctly even when
+    // Toast itself is (hypothetically) running on a non-Windows host.
+    const normalizedPath = path.win32.normalize(applicationPath).toLowerCase();
+    return getWindowsTrustedInstallDirs().some(dir => {
+      const normalizedDir = path.win32.normalize(dir).toLowerCase();
+      return normalizedPath === normalizedDir || normalizedPath.startsWith(`${normalizedDir}${path.win32.sep}`);
+    });
+  }
+
+  return false;
+}
 
 // Set via initializeApprovals(); ensureApproved falls back to allow when unset
 const state = {
@@ -61,14 +108,13 @@ function computeFingerprint(action) {
       return null;
     }
 
-    // A plain launch of an installed .app bundle stays gate-free to avoid
+    // A plain launch of a trusted installed app stays gate-free to avoid
     // prompting on every synced button. Launch parameters are
     // attacker-controllable capability regardless of target, and a path that
-    // isn't a standard app bundle (e.g. a script or arbitrary executable) is
-    // gated even without parameters, since it isn't a normal "open this app"
-    // button.
-    const isAppBundle = /\.app\/?$/i.test(applicationPath);
-    if (!action.applicationParameters && isAppBundle) {
+    // doesn't look like a normal installed app (e.g. a script or arbitrary
+    // executable) is gated even without parameters, since it isn't a normal
+    // "open this app" button.
+    if (!action.applicationParameters && isTrustedAppLaunch(applicationPath)) {
       return null;
     }
 

--- a/src/main/action-approval.js
+++ b/src/main/action-approval.js
@@ -54,12 +54,27 @@ function computeFingerprint(action) {
       scriptParams: action.scriptParams || '',
     };
   }
-  else if (action.action === 'application' && action.applicationParameters) {
-    // Launch arguments are attacker-controllable capability; a plain app launch
-    // (no parameters) stays gate-free to avoid prompting on every synced button.
+  else if (action.action === 'application') {
+    const applicationPath = action.applicationPath || '';
+    if (!applicationPath) {
+      // Empty slot placeholder; nothing to execute.
+      return null;
+    }
+
+    // A plain launch of an installed .app bundle stays gate-free to avoid
+    // prompting on every synced button. Launch parameters are
+    // attacker-controllable capability regardless of target, and a path that
+    // isn't a standard app bundle (e.g. a script or arbitrary executable) is
+    // gated even without parameters, since it isn't a normal "open this app"
+    // button.
+    const isAppBundle = /\.app\/?$/i.test(applicationPath);
+    if (!action.applicationParameters && isAppBundle) {
+      return null;
+    }
+
     canonical = {
       action: 'application',
-      applicationPath: action.applicationPath || '',
+      applicationPath,
       applicationParameters: action.applicationParameters || '',
     };
   }

--- a/src/main/actions/chain.js
+++ b/src/main/actions/chain.js
@@ -40,6 +40,7 @@ async function executeChainedActions(action, depth = 0) {
     const stopOnError = action.stopOnError !== false; // Default to true if not specified
     const results = [];
     let hasErrors = false;
+    let stoppedEarly = false;
 
     // Execute actions in sequence
     for (let i = 0; i < action.actions.length; i++) {
@@ -52,16 +53,27 @@ async function executeChainedActions(action, depth = 0) {
         result,
       });
 
-      // If this action failed and stopOnError is true, stop execution
-      if (!result.success && stopOnError) {
+      if (!result.success) {
         hasErrors = true;
-        break;
+        // If this action failed and stopOnError is true, stop execution
+        if (stopOnError) {
+          stoppedEarly = true;
+          break;
+        }
       }
+    }
+
+    let message = 'Chain executed successfully';
+    if (stoppedEarly) {
+      message = 'Chain execution stopped due to an error';
+    }
+    else if (hasErrors) {
+      message = 'Chain completed with one or more errors';
     }
 
     return {
       success: !hasErrors,
-      message: hasErrors ? 'Chain execution stopped due to an error' : 'Chain executed successfully',
+      message,
       results,
     };
   }

--- a/src/main/actions/exec.js
+++ b/src/main/actions/exec.js
@@ -42,6 +42,15 @@ function escapeShellArg(arg) {
 }
 
 /**
+ * Quote an app name for splicing into a shell command if it contains spaces
+ * @param {string} appName - Application name
+ * @returns {string} Quoted (if needed) app name
+ */
+function quoteAppName(appName) {
+  return appName.includes(' ') ? `"${appName}"` : appName;
+}
+
+/**
  * Escape AppleScript string
  * @param {string} str - String to escape for AppleScript
  * @returns {string} Escaped string
@@ -84,7 +93,7 @@ async function executeCommand(action) {
     }
 
     // Construct the modified command - handle quotes properly with escaping
-    const quotedAppName = appName.includes(' ') && !openAppMatch[1] ? `"${appName}"` : appName;
+    const quotedAppName = quoteAppName(appName);
     const escapedWorkingDir = escapeShellArg(expandedWorkingDir);
     let modifiedCommand;
     if (remainingArgs) {
@@ -182,7 +191,7 @@ async function openInTerminal(command, workingDir) {
       // Validate working directory
       if (fs.existsSync(expandedWorkingDir) && fs.statSync(expandedWorkingDir).isDirectory()) {
         // Construct the modified command for terminal execution - handle quotes properly with escaping
-        const quotedAppName = appName.includes(' ') && !openAppMatch[1] ? `"${appName}"` : appName;
+        const quotedAppName = quoteAppName(appName);
         const escapedWorkingDir = escapeShellArg(expandedWorkingDir);
         if (remainingArgs) {
           finalCommand = `open -a ${quotedAppName} ${remainingArgs} ${escapedWorkingDir}`;

--- a/src/main/api/auth.js
+++ b/src/main/api/auth.js
@@ -336,7 +336,12 @@ async function refreshAccessToken({ refreshToken, clientId, clientSecret }) {
     catch (tokenRequestError) {
       logger.error('Token renewal request failed:', tokenRequestError.message);
 
-      if (tokenRequestError.response?.status === 401) {
+      // The server returns 400 INVALID_GRANT when the refresh token itself is
+      // expired, already used, or otherwise invalid; 401 INVALID_CLIENT is
+      // reserved for a bad client_id/client_secret. Either way the current
+      // tokens can't be used again, so treat both as a session expiry.
+      const errorCode = tokenRequestError.response?.data?.error?.code;
+      if (errorCode === 'INVALID_GRANT' || tokenRequestError.response?.status === 401) {
         logger.info('Refresh token has expired. Re-login required');
 
         return {

--- a/src/main/api/auth.js
+++ b/src/main/api/auth.js
@@ -25,10 +25,12 @@ let isLoginInProgress = false;
 let loginStartTimestamp = 0;
 const LOGIN_TIMEOUT_MS = 60000; // Maximum login timeout of 1 minute
 
-// State store (for CSRF protection)
+// State store (for CSRF protection). Plain JSON, protected only by file
+// permissions — an encryptionKey here would be checked into source control
+// and give no real confidentiality, the same reasoning that led to storing
+// auth tokens as plaintext instead of a fake-encrypted file.
 const stateStore = new Store({
   name: 'auth-state',
-  encryptionKey: 'toast-app-auth-state',
   clearInvalidConfig: true,
 });
 
@@ -168,7 +170,7 @@ function initiateLogin(clientId) {
 
     // Log authentication URL
     logger.info('====== Authentication Request Info ======');
-    logger.info('Full authentication request URL:', authUrl.toString());
+    logger.info('Authentication request URL:', maskAuthUrl(authUrl.toString()));
     logger.info('========================================');
 
     // Activate login progress state

--- a/src/main/auth-manager.js
+++ b/src/main/auth-manager.js
@@ -492,6 +492,7 @@ function notifySettingsSynced(configData = null) {
     const config = createConfigStore();
     configData = {
       pages: config.get('pages'),
+      snippets: config.get('snippets'),
       appearance: config.get('appearance'),
       advanced: config.get('advanced'),
       subscription: config.get('subscription'),
@@ -507,6 +508,7 @@ function notifySettingsSynced(configData = null) {
     // 기본값으로 fallback
     configData = {
       pages: [],
+      snippets: [],
       appearance: {},
       advanced: {},
       subscription: {},

--- a/src/main/auth-manager.js
+++ b/src/main/auth-manager.js
@@ -396,7 +396,17 @@ async function fetchSubscription(forceRefresh = false) {
  * @returns {Promise<Object>} Refresh result
  */
 async function refreshAccessToken() {
-  return await auth.refreshAccessToken();
+  const result = await auth.refreshAccessToken();
+
+  // A dead refresh token means the user is effectively logged out; run the
+  // full logout flow so cloud sync stops and both windows are notified,
+  // instead of silently leaving the app in a stale "logged in" state.
+  if (!result.success && result.requireRelogin) {
+    logger.warn('Refresh token requires re-login; logging out');
+    await logout();
+  }
+
+  return result;
 }
 
 /**

--- a/src/main/cloud-sync.js
+++ b/src/main/cloud-sync.js
@@ -1028,6 +1028,7 @@ function initCloudSync(authManagerInstance, _userDataManagerInstance, configStor
           // 현재 설정 데이터 수집
           const configData = {
             pages: configStore.get('pages'),
+            snippets: configStore.get('snippets'),
             appearance: configStore.get('appearance'),
             advanced: configStore.get('advanced'),
             subscription: configStore.get('subscription'),

--- a/src/main/ipc/cloud-sync.js
+++ b/src/main/ipc/cloud-sync.js
@@ -136,6 +136,7 @@ function setupCloudSyncHandlers(windows, config) {
           // 현재 설정 데이터 수집
           const configData = {
             pages: config.get('pages'),
+            snippets: config.get('snippets'),
             appearance: config.get('appearance'),
             advanced: config.get('advanced'),
             subscription: config.get('subscription'),

--- a/src/main/ipc/config.js
+++ b/src/main/ipc/config.js
@@ -229,6 +229,10 @@ function setupConfigHandlers(windows, config) {
       const { resetToDefaults } = require('../config');
       resetToDefaults(config);
 
+      // Re-register the global hotkey since it may have changed back to the default
+      const { registerGlobalShortcuts } = require('../shortcuts');
+      registerGlobalShortcuts(config, windows);
+
       // Apply OS-level settings immediately, matching set-config's behavior
       app.setLoginItemSettings({ openAtLogin: config.get('advanced.launchAtLogin') || false });
       if (windows.toast && !windows.toast.isDestroyed()) {
@@ -266,6 +270,10 @@ function setupConfigHandlers(windows, config) {
       if (result) {
         const { trustCurrentConfig } = require('../action-approval');
         trustCurrentConfig(config);
+
+        // Re-register the global hotkey since the imported config may set a new one
+        const { registerGlobalShortcuts } = require('../shortcuts');
+        registerGlobalShortcuts(config, windows);
       }
 
       return result;

--- a/src/main/ipc/window.js
+++ b/src/main/ipc/window.js
@@ -12,6 +12,9 @@ const logger = createLogger('IPC');
 // Track button edit modal state
 let isModalOpen = false;
 
+// Pending delayed close() scheduled by close-settings, so a reopen can cancel it
+let pendingSettingsCloseTimeout = null;
+
 /**
  * Function to check if modal is currently open
  * @returns {boolean} Modal open state
@@ -146,6 +149,13 @@ function setupWindowHandlers(windows) {
 
   // Show settings window
   ipcMain.on('show-settings', () => {
+    // Cancel any close() scheduled by a previous close-settings, otherwise it
+    // would fire shortly after this reopen and force the window shut again.
+    if (pendingSettingsCloseTimeout) {
+      clearTimeout(pendingSettingsCloseTimeout);
+      pendingSettingsCloseTimeout = null;
+    }
+
     const { showSettingsWindow } = require('../windows');
     const { createConfigStore } = require('../config');
     showSettingsWindow(createConfigStore());
@@ -153,6 +163,13 @@ function setupWindowHandlers(windows) {
 
   // Show settings window with specific tab selected
   ipcMain.on('show-settings-tab', (event, tabName) => {
+    // Cancel any close() scheduled by a previous close-settings, otherwise it
+    // would fire shortly after this reopen and force the window shut again.
+    if (pendingSettingsCloseTimeout) {
+      clearTimeout(pendingSettingsCloseTimeout);
+      pendingSettingsCloseTimeout = null;
+    }
+
     const { showSettingsWindow } = require('../windows');
     const { createConfigStore } = require('../config');
 
@@ -168,8 +185,12 @@ function setupWindowHandlers(windows) {
     if (windows.settings && !windows.settings.isDestroyed()) {
       // First hide the window then close to prevent flashing
       windows.settings.hide();
-      // Close the window after a slight delay
-      setTimeout(() => {
+      // Close the window after a slight delay, unless show-settings cancels it first
+      if (pendingSettingsCloseTimeout) {
+        clearTimeout(pendingSettingsCloseTimeout);
+      }
+      pendingSettingsCloseTimeout = setTimeout(() => {
+        pendingSettingsCloseTimeout = null;
         if (windows.settings && !windows.settings.isDestroyed()) {
           windows.settings.close();
         }

--- a/src/main/logger.js
+++ b/src/main/logger.js
@@ -60,15 +60,15 @@ function createLogger(moduleName) {
 }
 
 /**
- * Mask sensitive query parameters (token, code) in a URL before logging it.
+ * Mask sensitive query parameters (token, code, state) in a URL before logging it.
  * @param {string} url
- * @returns {string} URL with token/code values replaced by '***'
+ * @returns {string} URL with token/code/state values replaced by '***'
  */
 function maskAuthUrl(url) {
   if (typeof url !== 'string') {
     return url;
   }
-  return url.replace(/([?&](?:token|code)=)[^&]+/g, '$1***');
+  return url.replace(/([?&](?:token|code|state)=)[^&]+/g, '$1***');
 }
 
 /**

--- a/src/main/updater.js
+++ b/src/main/updater.js
@@ -477,6 +477,7 @@ async function downloadUpdate() {
     return {
       success: false,
       error: 'Update download already in progress',
+      alreadyInProgress: true,
     };
   }
 
@@ -655,6 +656,14 @@ async function downloadAndInstallUpdate(version) {
 
   const downloadResult = await downloadUpdate();
   if (!downloadResult.success) {
+    if (downloadResult.alreadyInProgress) {
+      // A download triggered by an earlier click is still running; leave the
+      // tray showing 'downloading' instead of reverting it to 'available',
+      // which would look like that download had failed or been cancelled.
+      logger.info('One-click upgrade skipped: a download is already in progress');
+      return downloadResult;
+    }
+
     logger.error('One-click upgrade failed during download:', downloadResult.error);
     notifyTrayUpdateState('available', version);
     return downloadResult;

--- a/src/renderer/pages/settings/index.js
+++ b/src/renderer/pages/settings/index.js
@@ -116,72 +116,92 @@ document.addEventListener('DOMContentLoaded', () => {
   // Config update listener - 필요한 설정만 업데이트하도록 최적화
   window.addEventListener('config-loaded', event => {
     window.settings.log.info('config-loaded 이벤트 수신 - 최적화된 업데이트 사용');
-    const newConfig = event.detail;
+    applyConfigUpdate(event.detail);
+  });
 
-    // 이전 설정과 새 설정을 비교해 필요한 요소만 업데이트
-    if (newConfig) {
-      // 설정 객체 업데이트
-      updateConfig(newConfig);
-
-      // 현재 활성화된 탭만 업데이트 (전체 UI 초기화 방지)
-      const activeTab = Array.from(document.querySelectorAll('.settings-tab')).find(tab => tab.classList.contains('active'));
-      if (activeTab) {
-        const tabId = activeTab.id;
-        window.settings.log.info(`현재 활성 탭 "${tabId}"만 선택적으로 업데이트`);
-
-        // 선택적으로 필요한 설정만 업데이트 (통합 Settings 탭 = General/Appearance/Advanced 섹션)
-        if (tabId === 'settings') {
-          const globalHotkeyInput = document.getElementById('global-hotkey');
-          const launchAtLoginCheckbox = document.getElementById('launch-at-login');
-
-          if (globalHotkeyInput) {
-            globalHotkeyInput.value = config.globalHotkey || '';
-          }
-          if (launchAtLoginCheckbox) {
-            launchAtLoginCheckbox.checked = config.advanced?.launchAtLogin || false;
-          }
-
-          const themeSelect = document.getElementById('theme');
-          const positionSelect = document.getElementById('position');
-          const sizeSelect = document.getElementById('size');
-          const opacityRange = document.getElementById('opacity');
-          const opacityValue = document.getElementById('opacity-value');
-
-          if (themeSelect) {
-            themeSelect.value = config.appearance?.theme || 'system';
-          }
-          if (positionSelect) {
-            positionSelect.value = config.appearance?.position || 'center';
-          }
-          if (sizeSelect) {
-            sizeSelect.value = config.appearance?.size || 'medium';
-          }
-          if (opacityRange) {
-            opacityRange.value = config.appearance?.opacity || 0.95;
-            if (opacityValue) {
-              opacityValue.textContent = opacityRange.value;
-            }
-          }
-
-          const hideAfterActionCheckbox = document.getElementById('hide-after-action');
-          const hideOnBlurCheckbox = document.getElementById('hide-on-blur');
-          const hideOnEscapeCheckbox = document.getElementById('hide-on-escape');
-          const showInTaskbarCheckbox = document.getElementById('show-in-taskbar');
-
-          if (hideAfterActionCheckbox) {
-            hideAfterActionCheckbox.checked = config.advanced?.hideAfterAction !== false;
-          }
-          if (hideOnBlurCheckbox) {
-            hideOnBlurCheckbox.checked = config.advanced?.hideOnBlur !== false;
-          }
-          if (hideOnEscapeCheckbox) {
-            hideOnEscapeCheckbox.checked = config.advanced?.hideOnEscape !== false;
-          }
-          if (showInTaskbarCheckbox) {
-            showInTaskbarCheckbox.checked = config.advanced?.showInTaskbar || false;
-          }
-        }
-      }
-    }
+  // 백그라운드 클라우드 동기화 병합 등으로 메인 프로세스가 config-updated를
+  // 브로드캐스트할 때도 동일하게 반영 (그렇지 않으면 이 창은 계속 예전 config를
+  // 들고 있다가, 다음 저장 시 병합된 변경사항을 덮어써 버린다)
+  window.addEventListener('config-updated', event => {
+    window.settings.log.info('config-updated 이벤트 수신 - 백그라운드 변경 반영');
+    applyConfigUpdate(event.detail);
   });
 });
+
+/**
+ * 새 config 페이로드를 이미 초기화된 탭에 반영 (전체 UI 재초기화 없이)
+ * @param {Object} newConfig - 갱신된 설정 객체
+ */
+function applyConfigUpdate(newConfig) {
+  // 이전 설정과 새 설정을 비교해 필요한 요소만 업데이트
+  if (!newConfig) {
+    return;
+  }
+
+  // 설정 객체 업데이트
+  updateConfig(newConfig);
+
+  // 스니펫은 탭 초기화 시점에 로컬 상태로 스냅샷되므로, 백그라운드 동기화로
+  // 병합된 변경사항을 여기서 반영하지 않으면 다음 편집 시 그대로 덮어써진다.
+  initializeSnippetsSettings();
+
+  // 현재 활성화된 탭만 업데이트 (전체 UI 초기화 방지)
+  const activeTab = Array.from(document.querySelectorAll('.settings-tab')).find(tab => tab.classList.contains('active'));
+  if (activeTab) {
+    const tabId = activeTab.id;
+    window.settings.log.info(`현재 활성 탭 "${tabId}"만 선택적으로 업데이트`);
+
+    // 선택적으로 필요한 설정만 업데이트 (통합 Settings 탭 = General/Appearance/Advanced 섹션)
+    if (tabId === 'settings') {
+      const globalHotkeyInput = document.getElementById('global-hotkey');
+      const launchAtLoginCheckbox = document.getElementById('launch-at-login');
+
+      if (globalHotkeyInput) {
+        globalHotkeyInput.value = config.globalHotkey || '';
+      }
+      if (launchAtLoginCheckbox) {
+        launchAtLoginCheckbox.checked = config.advanced?.launchAtLogin || false;
+      }
+
+      const themeSelect = document.getElementById('theme');
+      const positionSelect = document.getElementById('position');
+      const sizeSelect = document.getElementById('size');
+      const opacityRange = document.getElementById('opacity');
+      const opacityValue = document.getElementById('opacity-value');
+
+      if (themeSelect) {
+        themeSelect.value = config.appearance?.theme || 'system';
+      }
+      if (positionSelect) {
+        positionSelect.value = config.appearance?.position || 'center';
+      }
+      if (sizeSelect) {
+        sizeSelect.value = config.appearance?.size || 'medium';
+      }
+      if (opacityRange) {
+        opacityRange.value = config.appearance?.opacity || 0.95;
+        if (opacityValue) {
+          opacityValue.textContent = opacityRange.value;
+        }
+      }
+
+      const hideAfterActionCheckbox = document.getElementById('hide-after-action');
+      const hideOnBlurCheckbox = document.getElementById('hide-on-blur');
+      const hideOnEscapeCheckbox = document.getElementById('hide-on-escape');
+      const showInTaskbarCheckbox = document.getElementById('show-in-taskbar');
+
+      if (hideAfterActionCheckbox) {
+        hideAfterActionCheckbox.checked = config.advanced?.hideAfterAction !== false;
+      }
+      if (hideOnBlurCheckbox) {
+        hideOnBlurCheckbox.checked = config.advanced?.hideOnBlur !== false;
+      }
+      if (hideOnEscapeCheckbox) {
+        hideOnEscapeCheckbox.checked = config.advanced?.hideOnEscape !== false;
+      }
+      if (showInTaskbarCheckbox) {
+        showInTaskbarCheckbox.checked = config.advanced?.showInTaskbar || false;
+      }
+    }
+  }
+}

--- a/src/renderer/pages/settings/index.js
+++ b/src/renderer/pages/settings/index.js
@@ -138,70 +138,77 @@ function applyConfigUpdate(newConfig) {
     return;
   }
 
-  // 설정 객체 업데이트
-  updateConfig(newConfig);
+  try {
+    // 일부 config-updated 브로드캐스트(수동 동기화, 로그인 후 동기화 등)는 snippets를
+    // 포함하지 않는 부분 스냅샷을 보낸다. 완전 치환 대신 병합해 누락된 필드가 기존 값을
+    // 지워버리지 않게 한다.
+    updateConfig({ ...config, ...newConfig });
 
-  // 스니펫은 탭 초기화 시점에 로컬 상태로 스냅샷되므로, 백그라운드 동기화로
-  // 병합된 변경사항을 여기서 반영하지 않으면 다음 편집 시 그대로 덮어써진다.
-  initializeSnippetsSettings();
+    // 스니펫은 탭 초기화 시점에 로컬 상태로 스냅샷되므로, 백그라운드 동기화로
+    // 병합된 변경사항을 여기서 반영하지 않으면 다음 편집 시 그대로 덮어써진다.
+    initializeSnippetsSettings();
 
-  // 현재 활성화된 탭만 업데이트 (전체 UI 초기화 방지)
-  const activeTab = Array.from(document.querySelectorAll('.settings-tab')).find(tab => tab.classList.contains('active'));
-  if (activeTab) {
-    const tabId = activeTab.id;
-    window.settings.log.info(`현재 활성 탭 "${tabId}"만 선택적으로 업데이트`);
+    // 현재 활성화된 탭만 업데이트 (전체 UI 초기화 방지)
+    const activeTab = Array.from(document.querySelectorAll('.settings-tab')).find(tab => tab.classList.contains('active'));
+    if (activeTab) {
+      const tabId = activeTab.id;
+      window.settings.log.info(`현재 활성 탭 "${tabId}"만 선택적으로 업데이트`);
 
-    // 선택적으로 필요한 설정만 업데이트 (통합 Settings 탭 = General/Appearance/Advanced 섹션)
-    if (tabId === 'settings') {
-      const globalHotkeyInput = document.getElementById('global-hotkey');
-      const launchAtLoginCheckbox = document.getElementById('launch-at-login');
+      // 선택적으로 필요한 설정만 업데이트 (통합 Settings 탭 = General/Appearance/Advanced 섹션)
+      if (tabId === 'settings') {
+        const globalHotkeyInput = document.getElementById('global-hotkey');
+        const launchAtLoginCheckbox = document.getElementById('launch-at-login');
 
-      if (globalHotkeyInput) {
-        globalHotkeyInput.value = config.globalHotkey || '';
-      }
-      if (launchAtLoginCheckbox) {
-        launchAtLoginCheckbox.checked = config.advanced?.launchAtLogin || false;
-      }
+        if (globalHotkeyInput) {
+          globalHotkeyInput.value = config.globalHotkey || '';
+        }
+        if (launchAtLoginCheckbox) {
+          launchAtLoginCheckbox.checked = config.advanced?.launchAtLogin || false;
+        }
 
-      const themeSelect = document.getElementById('theme');
-      const positionSelect = document.getElementById('position');
-      const sizeSelect = document.getElementById('size');
-      const opacityRange = document.getElementById('opacity');
-      const opacityValue = document.getElementById('opacity-value');
+        const themeSelect = document.getElementById('theme');
+        const positionSelect = document.getElementById('position');
+        const sizeSelect = document.getElementById('size');
+        const opacityRange = document.getElementById('opacity');
+        const opacityValue = document.getElementById('opacity-value');
 
-      if (themeSelect) {
-        themeSelect.value = config.appearance?.theme || 'system';
-      }
-      if (positionSelect) {
-        positionSelect.value = config.appearance?.position || 'center';
-      }
-      if (sizeSelect) {
-        sizeSelect.value = config.appearance?.size || 'medium';
-      }
-      if (opacityRange) {
-        opacityRange.value = config.appearance?.opacity || 0.95;
-        if (opacityValue) {
-          opacityValue.textContent = opacityRange.value;
+        if (themeSelect) {
+          themeSelect.value = config.appearance?.theme || 'system';
+        }
+        if (positionSelect) {
+          positionSelect.value = config.appearance?.position || 'center';
+        }
+        if (sizeSelect) {
+          sizeSelect.value = config.appearance?.size || 'medium';
+        }
+        if (opacityRange) {
+          opacityRange.value = config.appearance?.opacity || 0.95;
+          if (opacityValue) {
+            opacityValue.textContent = opacityRange.value;
+          }
+        }
+
+        const hideAfterActionCheckbox = document.getElementById('hide-after-action');
+        const hideOnBlurCheckbox = document.getElementById('hide-on-blur');
+        const hideOnEscapeCheckbox = document.getElementById('hide-on-escape');
+        const showInTaskbarCheckbox = document.getElementById('show-in-taskbar');
+
+        if (hideAfterActionCheckbox) {
+          hideAfterActionCheckbox.checked = config.advanced?.hideAfterAction !== false;
+        }
+        if (hideOnBlurCheckbox) {
+          hideOnBlurCheckbox.checked = config.advanced?.hideOnBlur !== false;
+        }
+        if (hideOnEscapeCheckbox) {
+          hideOnEscapeCheckbox.checked = config.advanced?.hideOnEscape !== false;
+        }
+        if (showInTaskbarCheckbox) {
+          showInTaskbarCheckbox.checked = config.advanced?.showInTaskbar || false;
         }
       }
-
-      const hideAfterActionCheckbox = document.getElementById('hide-after-action');
-      const hideOnBlurCheckbox = document.getElementById('hide-on-blur');
-      const hideOnEscapeCheckbox = document.getElementById('hide-on-escape');
-      const showInTaskbarCheckbox = document.getElementById('show-in-taskbar');
-
-      if (hideAfterActionCheckbox) {
-        hideAfterActionCheckbox.checked = config.advanced?.hideAfterAction !== false;
-      }
-      if (hideOnBlurCheckbox) {
-        hideOnBlurCheckbox.checked = config.advanced?.hideOnBlur !== false;
-      }
-      if (hideOnEscapeCheckbox) {
-        hideOnEscapeCheckbox.checked = config.advanced?.hideOnEscape !== false;
-      }
-      if (showInTaskbarCheckbox) {
-        showInTaskbarCheckbox.checked = config.advanced?.showInTaskbar || false;
-      }
     }
+  }
+  catch (error) {
+    window.settings.log.error('applyConfigUpdate 오류:', error);
   }
 }

--- a/src/renderer/pages/settings/modules/about-settings.js
+++ b/src/renderer/pages/settings/modules/about-settings.js
@@ -365,7 +365,12 @@ export function handleInstallError(error) {
     const originalContent = updateMessage.textContent;
 
     // 오류 메시지 설정
-    updateMessage.innerHTML = `<span class="error-message">Error occurred while installing update:</span> ${error.message || 'Unknown error'}`;
+    updateMessage.textContent = '';
+    const errorLabel = document.createElement('span');
+    errorLabel.className = 'error-message';
+    errorLabel.textContent = 'Error occurred while installing update:';
+    updateMessage.appendChild(errorLabel);
+    updateMessage.appendChild(document.createTextNode(` ${error.message || 'Unknown error'}`));
 
     // 추가 도움말 표시
     const helpText = document.createElement('p');

--- a/src/renderer/pages/toast/modules/auth.js
+++ b/src/renderer/pages/toast/modules/auth.js
@@ -297,7 +297,7 @@ export function updateProfileDisplay() {
       // Handle image load error
       img.onerror = function () {
         // Replace with initials if image load fails
-        profileAvatar.innerHTML = getInitials(userProfile.name || userProfile.display_name || 'User');
+        profileAvatar.textContent = getInitials(userProfile.name || userProfile.display_name || 'User');
       };
 
       // Apply effect when image load completes
@@ -312,7 +312,7 @@ export function updateProfileDisplay() {
     else {
       // Use initials if no image available
       const initials = getInitials(userProfile.name || userProfile.display_name || 'User');
-      profileAvatar.innerHTML = initials;
+      profileAvatar.textContent = initials;
     }
 
     // Set name and email

--- a/src/renderer/pages/toast/modules/buttons.js
+++ b/src/renderer/pages/toast/modules/buttons.js
@@ -165,9 +165,23 @@ function enableButtonDrag(buttonElement, index) {
       }
     };
 
+    const onWindowHide = () => {
+      // Abandon the drag if the window hides mid-drag (blur, global hotkey,
+      // Escape); there is no mouseup in that case, so clean up here instead
+      // of leaking the document-level listeners and the floating drag-ghost.
+      document.removeEventListener('mousemove', onMouseMove);
+      document.removeEventListener('mouseup', onMouseUp);
+      if (ghost) {
+        ghost.remove();
+      }
+      buttonElement.classList.remove('dragging');
+      clearDropTarget();
+    };
+
     const onMouseUp = event => {
       document.removeEventListener('mousemove', onMouseMove);
       document.removeEventListener('mouseup', onMouseUp);
+      window.removeEventListener('before-window-hide', onWindowHide);
 
       if (!dragging) {
         // Plain click; let the click handler run
@@ -203,6 +217,7 @@ function enableButtonDrag(buttonElement, index) {
 
     document.addEventListener('mousemove', onMouseMove);
     document.addEventListener('mouseup', onMouseUp);
+    window.addEventListener('before-window-hide', onWindowHide);
   });
 }
 

--- a/src/renderer/pages/toast/modules/buttons.js
+++ b/src/renderer/pages/toast/modules/buttons.js
@@ -171,6 +171,7 @@ function enableButtonDrag(buttonElement, index) {
       // of leaking the document-level listeners and the floating drag-ghost.
       document.removeEventListener('mousemove', onMouseMove);
       document.removeEventListener('mouseup', onMouseUp);
+      window.removeEventListener('before-window-hide', onWindowHide);
       if (ghost) {
         ghost.remove();
       }

--- a/src/renderer/preload/settings.js
+++ b/src/renderer/preload/settings.js
@@ -35,10 +35,6 @@ contextBridge.exposeInMainWorld('settings', {
   importConfig: filePath => ipcRenderer.invoke('import-config', filePath),
   exportConfig: filePath => ipcRenderer.invoke('export-config', filePath),
 
-  // Actions
-  testAction: action => ipcRenderer.invoke('test-action', action),
-  validateAction: action => ipcRenderer.invoke('validate-action', action),
-
   // Window control
   showToast: () => ipcRenderer.send('show-toast'),
   closeWindow: () => ipcRenderer.send('close-settings'),

--- a/tests/unit/action-approval.test.js
+++ b/tests/unit/action-approval.test.js
@@ -94,6 +94,41 @@ describe('Action Approval', () => {
       const other = { action: 'application', applicationPath: '/Applications/Calculator.app', applicationParameters: '--other' };
       expect(computeFingerprint(withParams)).not.toBe(computeFingerprint(other));
     });
+
+    describe('on Windows', () => {
+      let originalPlatform;
+      let originalEnv;
+
+      beforeEach(() => {
+        originalPlatform = process.platform;
+        originalEnv = { ...process.env };
+        Object.defineProperty(process, 'platform', { value: 'win32' });
+        process.env.ProgramFiles = 'C:\\Program Files';
+        process.env['ProgramFiles(x86)'] = 'C:\\Program Files (x86)';
+        process.env.LOCALAPPDATA = 'C:\\Users\\test\\AppData\\Local';
+        process.env.WINDIR = 'C:\\Windows';
+      });
+
+      afterEach(() => {
+        Object.defineProperty(process, 'platform', { value: originalPlatform });
+        process.env = originalEnv;
+      });
+
+      test('should stay gate-free for a .exe under a standard install directory', () => {
+        expect(computeFingerprint({ action: 'application', applicationPath: 'C:\\Program Files\\Toast\\Toast.exe' })).toBeNull();
+        expect(computeFingerprint({ action: 'application', applicationPath: 'C:\\Program Files (x86)\\App\\App.exe' })).toBeNull();
+        expect(computeFingerprint({ action: 'application', applicationPath: 'C:\\Users\\test\\AppData\\Local\\Programs\\App\\App.exe' })).toBeNull();
+        expect(computeFingerprint({ action: 'application', applicationPath: 'C:\\Windows\\notepad.exe' })).toBeNull();
+      });
+
+      test('should fingerprint a .exe outside the standard install directories', () => {
+        expect(computeFingerprint({ action: 'application', applicationPath: 'C:\\Users\\test\\Downloads\\random.exe' })).not.toBeNull();
+      });
+
+      test('should fingerprint a non-.exe launch even under a standard install directory', () => {
+        expect(computeFingerprint({ action: 'application', applicationPath: 'C:\\Program Files\\Toast\\run.bat' })).not.toBeNull();
+      });
+    });
   });
 
   describe('collectRiskyFingerprints', () => {

--- a/tests/unit/action-approval.test.js
+++ b/tests/unit/action-approval.test.js
@@ -75,24 +75,37 @@ describe('Action Approval', () => {
       expect(computeFingerprint(null)).toBeNull();
     });
 
-    test('should stay gate-free for a plain .app bundle launch with no parameters', () => {
-      expect(computeFingerprint({ action: 'application', applicationPath: '/Applications/Calculator.app' })).toBeNull();
-      expect(computeFingerprint({ action: 'application', applicationPath: '/Applications/Visual Studio Code.app/' })).toBeNull();
-    });
+    describe('on macOS', () => {
+      let originalPlatform;
 
-    test('should fingerprint a parameterless application launch when the path is not a .app bundle', () => {
-      expect(computeFingerprint({ action: 'application', applicationPath: '/usr/local/bin/some-script.sh' })).not.toBeNull();
-      expect(computeFingerprint({ action: 'application', applicationPath: '/Users/me/run.command' })).not.toBeNull();
-    });
+      beforeEach(() => {
+        originalPlatform = process.platform;
+        Object.defineProperty(process, 'platform', { value: 'darwin' });
+      });
 
-    test('should fingerprint application actions that carry launch parameters', () => {
-      const withParams = { action: 'application', applicationPath: '/Applications/Calculator.app', applicationParameters: '--flag' };
-      expect(computeFingerprint(withParams)).not.toBeNull();
-      // Empty parameters stay gate-free for an actual .app bundle
-      expect(computeFingerprint({ action: 'application', applicationPath: '/Applications/Calculator.app', applicationParameters: '' })).toBeNull();
-      // Fingerprint tracks the parameters that make it risky
-      const other = { action: 'application', applicationPath: '/Applications/Calculator.app', applicationParameters: '--other' };
-      expect(computeFingerprint(withParams)).not.toBe(computeFingerprint(other));
+      afterEach(() => {
+        Object.defineProperty(process, 'platform', { value: originalPlatform });
+      });
+
+      test('should stay gate-free for a plain .app bundle launch with no parameters', () => {
+        expect(computeFingerprint({ action: 'application', applicationPath: '/Applications/Calculator.app' })).toBeNull();
+        expect(computeFingerprint({ action: 'application', applicationPath: '/Applications/Visual Studio Code.app/' })).toBeNull();
+      });
+
+      test('should fingerprint a parameterless application launch when the path is not a .app bundle', () => {
+        expect(computeFingerprint({ action: 'application', applicationPath: '/usr/local/bin/some-script.sh' })).not.toBeNull();
+        expect(computeFingerprint({ action: 'application', applicationPath: '/Users/me/run.command' })).not.toBeNull();
+      });
+
+      test('should fingerprint application actions that carry launch parameters', () => {
+        const withParams = { action: 'application', applicationPath: '/Applications/Calculator.app', applicationParameters: '--flag' };
+        expect(computeFingerprint(withParams)).not.toBeNull();
+        // Empty parameters stay gate-free for an actual .app bundle
+        expect(computeFingerprint({ action: 'application', applicationPath: '/Applications/Calculator.app', applicationParameters: '' })).toBeNull();
+        // Fingerprint tracks the parameters that make it risky
+        const other = { action: 'application', applicationPath: '/Applications/Calculator.app', applicationParameters: '--other' };
+        expect(computeFingerprint(withParams)).not.toBe(computeFingerprint(other));
+      });
     });
 
     describe('on Windows', () => {

--- a/tests/unit/action-approval.test.js
+++ b/tests/unit/action-approval.test.js
@@ -71,17 +71,27 @@ describe('Action Approval', () => {
 
     test('should return null for non-risky actions', () => {
       expect(computeFingerprint({ action: 'open', url: 'https://example.com' })).toBeNull();
-      expect(computeFingerprint({ action: 'application', applicationPath: '/app' })).toBeNull();
+      expect(computeFingerprint({ action: 'application', applicationPath: '' })).toBeNull();
       expect(computeFingerprint(null)).toBeNull();
     });
 
+    test('should stay gate-free for a plain .app bundle launch with no parameters', () => {
+      expect(computeFingerprint({ action: 'application', applicationPath: '/Applications/Calculator.app' })).toBeNull();
+      expect(computeFingerprint({ action: 'application', applicationPath: '/Applications/Visual Studio Code.app/' })).toBeNull();
+    });
+
+    test('should fingerprint a parameterless application launch when the path is not a .app bundle', () => {
+      expect(computeFingerprint({ action: 'application', applicationPath: '/usr/local/bin/some-script.sh' })).not.toBeNull();
+      expect(computeFingerprint({ action: 'application', applicationPath: '/Users/me/run.command' })).not.toBeNull();
+    });
+
     test('should fingerprint application actions that carry launch parameters', () => {
-      const withParams = { action: 'application', applicationPath: '/app', applicationParameters: '--flag' };
+      const withParams = { action: 'application', applicationPath: '/Applications/Calculator.app', applicationParameters: '--flag' };
       expect(computeFingerprint(withParams)).not.toBeNull();
-      // Empty parameters stay gate-free
-      expect(computeFingerprint({ action: 'application', applicationPath: '/app', applicationParameters: '' })).toBeNull();
+      // Empty parameters stay gate-free for an actual .app bundle
+      expect(computeFingerprint({ action: 'application', applicationPath: '/Applications/Calculator.app', applicationParameters: '' })).toBeNull();
       // Fingerprint tracks the parameters that make it risky
-      const other = { action: 'application', applicationPath: '/app', applicationParameters: '--other' };
+      const other = { action: 'application', applicationPath: '/Applications/Calculator.app', applicationParameters: '--other' };
       expect(computeFingerprint(withParams)).not.toBe(computeFingerprint(other));
     });
   });

--- a/tests/unit/actions/chain.test.js
+++ b/tests/unit/actions/chain.test.js
@@ -240,8 +240,8 @@ describe('Chain Action', () => {
       expect(executeAction).toHaveBeenNthCalledWith(3, testActions[2], 1);
       
       expect(result).toEqual({
-        success: true, // Overall success because not all actions failed
-        message: 'Chain executed successfully',
+        success: false, // One of the actions failed, even though execution continued
+        message: 'Chain completed with one or more errors',
         results: [
           { index: 0, action: testActions[0], result: expectedResults[0] },
           { index: 1, action: testActions[1], result: expectedResults[1] },
@@ -273,8 +273,8 @@ describe('Chain Action', () => {
 
       expect(executeAction).toHaveBeenCalledTimes(3);
       expect(result).toEqual({
-        success: true, // Success because execution completed without throwing
-        message: 'Chain executed successfully',
+        success: false, // All actions failed
+        message: 'Chain completed with one or more errors',
         results: [
           { index: 0, action: testActions[0], result: expectedResults[0] },
           { index: 1, action: testActions[1], result: expectedResults[1] },
@@ -476,8 +476,8 @@ describe('Chain Action', () => {
       const result = await executeChainedActions(action);
 
       expect(executeAction).toHaveBeenCalledTimes(5);
-      expect(result.success).toBe(true); // Should be true because execution completed
-      expect(result.message).toBe('Chain executed successfully');
+      expect(result.success).toBe(false); // Should be false because some actions failed
+      expect(result.message).toBe('Chain completed with one or more errors');
       expect(result.results).toHaveLength(5);
       
       // Verify each result maintains correct structure

--- a/tests/unit/actions/exec.test.js
+++ b/tests/unit/actions/exec.test.js
@@ -186,7 +186,7 @@ describe('Exec Action', () => {
 
         // Uses escapeShellArg which wraps path in single quotes for Unix
         expect(exec).toHaveBeenCalledWith(
-          "open -a Visual Studio Code '/test/project'",
+          "open -a \"Visual Studio Code\" '/test/project'",
           { shell: true },
           expect.any(Function)
         );
@@ -225,7 +225,7 @@ describe('Exec Action', () => {
 
         // Uses escapeShellArg which wraps path in single quotes for Unix
         expect(exec).toHaveBeenCalledWith(
-          "open -a Visual Studio Code --new-window '/test/project'",
+          "open -a \"Visual Studio Code\" --new-window '/test/project'",
           { shell: true },
           expect.any(Function)
         );

--- a/tests/unit/api/auth.test.js
+++ b/tests/unit/api/auth.test.js
@@ -198,6 +198,57 @@ describe('API Auth Module (P0)', () => {
         code: 'REFRESH_FAILED'
       });
     });
+
+    test('should treat a 400 INVALID_GRANT response as a session expiry', async () => {
+      const params = {
+        refreshToken: 'refresh-token-123',
+        clientId: 'test-client-id',
+        clientSecret: 'test-client-secret'
+      };
+
+      const error = new Error('Request failed with status code 400');
+      error.response = {
+        status: 400,
+        data: {
+          success: false,
+          error: {
+            code: 'INVALID_GRANT',
+            message: 'Invalid refresh token'
+          }
+        }
+      };
+      mockClient.post.mockRejectedValue(error);
+
+      const result = await authApi.refreshAccessToken(params);
+
+      expect(result).toEqual({
+        success: false,
+        error: 'Your login session has expired. Please log in again.',
+        code: 'SESSION_EXPIRED',
+        requireRelogin: true
+      });
+    });
+
+    test('should still treat a bare 401 response as a session expiry', async () => {
+      const params = {
+        refreshToken: 'refresh-token-123',
+        clientId: 'test-client-id',
+        clientSecret: 'test-client-secret'
+      };
+
+      const error = new Error('Request failed with status code 401');
+      error.response = { status: 401, data: {} };
+      mockClient.post.mockRejectedValue(error);
+
+      const result = await authApi.refreshAccessToken(params);
+
+      expect(result).toEqual({
+        success: false,
+        error: 'Your login session has expired. Please log in again.',
+        code: 'SESSION_EXPIRED',
+        requireRelogin: true
+      });
+    });
   });
 
   describe('Token Revocation', () => {

--- a/tests/unit/auth-manager.test.js
+++ b/tests/unit/auth-manager.test.js
@@ -574,5 +574,23 @@ describe('Authentication Manager', () => {
         expect.any(Object)
       );
     });
+
+    test('should include snippets when building config data from the store', () => {
+      const storeValues = {
+        pages: [{ id: 'page-1' }],
+        snippets: [{ id: 'sn-1', keyword: 'hi', content: 'hello' }],
+        appearance: {},
+        advanced: {},
+        subscription: {},
+      };
+      mockConfigStore.get.mockImplementation(key => storeValues[key]);
+
+      authManager.notifySettingsSynced();
+
+      expect(mockWindows.settings.webContents.send).toHaveBeenCalledWith(
+        'config-updated',
+        expect.objectContaining({ snippets: storeValues.snippets })
+      );
+    });
   });
 });

--- a/tests/unit/auth-manager.test.js
+++ b/tests/unit/auth-manager.test.js
@@ -150,6 +150,31 @@ describe('Authentication Manager', () => {
       expect(result).toEqual(mockResult);
       expect(mockAuth.refreshAccessToken).toHaveBeenCalled();
     });
+
+    test('should log out and notify both windows when the refresh token requires re-login', async () => {
+      const mockResult = {
+        success: false,
+        error: 'Your login session has expired. Please log in again.',
+        code: 'SESSION_EXPIRED',
+        requireRelogin: true,
+      };
+      mockAuth.refreshAccessToken.mockResolvedValue(mockResult);
+
+      const result = await authManager.refreshAccessToken();
+
+      expect(result).toEqual(mockResult);
+      expect(mockAuth.logout).toHaveBeenCalled();
+      expect(mockWindows.toast.webContents.send).toHaveBeenCalledWith('auth-state-changed', expect.objectContaining({ isAuthenticated: false }));
+    });
+
+    test('should not log out when refresh fails for a reason other than requireRelogin', async () => {
+      const mockResult = { success: false, error: 'Network error', code: 'REFRESH_FAILED' };
+      mockAuth.refreshAccessToken.mockResolvedValue(mockResult);
+
+      await authManager.refreshAccessToken();
+
+      expect(mockAuth.logout).not.toHaveBeenCalled();
+    });
   });
 
   describe('User Profile Management', () => {

--- a/tests/unit/cloud-sync.test.js
+++ b/tests/unit/cloud-sync.test.js
@@ -634,6 +634,43 @@ describe('Cloud Sync Module', () => {
       expect(result.success).toBe(true);
       expect(mockConfigStore.set).toHaveBeenCalledWith('pages', [{ id: 1, name: 'Server Page' }]);
     });
+
+    test('should include snippets in the config data sent to the UI after login sync', async () => {
+      const configModule = require('../../src/main/config');
+      configModule.hasUnsyncedChanges.mockReturnValue(false);
+      configModule.getSyncMetadata.mockReturnValue({
+        lastModifiedAt: Date.now() - 10 * 60 * 1000,
+        lastModifiedDevice: 'test-device',
+        lastSyncedAt: Date.now() - 10 * 60 * 1000,
+        lastSyncedDevice: 'test-device',
+      });
+
+      mockConfigStore.get.mockImplementation(key => {
+        const mockData = {
+          pages: [{ id: 1, name: 'Server Page' }],
+          snippets: [{ id: 'sn-1', keyword: 'hi', content: 'hello' }],
+          appearance: { theme: 'dark' },
+          advanced: { autoStart: true },
+        };
+        return mockData[key] || {};
+      });
+
+      mockApiSync.downloadSettings.mockResolvedValue({
+        success: true,
+        data: {},
+        normalized: { pages: [{ id: 1, name: 'Server Page' }] },
+        syncMetadata: { lastModifiedAt: Date.now() },
+      });
+
+      cloudSync.updateCloudSyncSettings(true);
+      const syncManager = cloudSync.getSyncManager();
+
+      await syncManager.syncAfterLogin();
+
+      expect(mockAuthManager.notifySettingsSynced).toHaveBeenCalledWith(
+        expect.objectContaining({ snippets: [{ id: 'sn-1', keyword: 'hi', content: 'hello' }] })
+      );
+    });
   });
 
   describe('Sync Settings Integration', () => {

--- a/tests/unit/ipc.test.js
+++ b/tests/unit/ipc.test.js
@@ -458,6 +458,17 @@ describe('IPC Handlers', () => {
       expect(mockApp.setLoginItemSettings).toHaveBeenCalledWith({ openAtLogin: false });
       expect(mockWindows.toast.setSkipTaskbar).toHaveBeenCalledWith(true);
     });
+
+    test('should re-register the global hotkey after reset-config', async () => {
+      setupIpcHandlers(mockWindows);
+
+      const handler = mockIpcMain.handle.mock.calls
+        .find(([event]) => event === 'reset-config')[1];
+
+      await handler();
+
+      expect(mockShortcuts.registerGlobalShortcuts).toHaveBeenCalledWith(mockConfig, mockWindows);
+    });
   });
 
   describe('authentication handlers', () => {

--- a/tests/unit/ipc.test.js
+++ b/tests/unit/ipc.test.js
@@ -276,10 +276,52 @@ describe('IPC Handlers', () => {
       const onEvents = mockIpcMain.on.mock.calls.map(call => call[0]);
 
       expect(handleEvents).toContain('set-always-on-top');
-      expect(handleEvents).toContain('get-window-position'); 
+      expect(handleEvents).toContain('get-window-position');
       expect(handleEvents).toContain('show-window');
       expect(onEvents).toContain('show-toast');
       expect(onEvents).toContain('hide-toast');
+    });
+  });
+
+  describe('settings window close/reopen race', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    test('should close the settings window after a delay when close-settings fires', () => {
+      setupIpcHandlers(mockWindows);
+
+      const closeHandler = mockIpcMain.on.mock.calls
+        .find(([event]) => event === 'close-settings')[1];
+
+      closeHandler();
+
+      expect(mockWindows.settings.hide).toHaveBeenCalled();
+      expect(mockWindows.settings.close).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(500);
+
+      expect(mockWindows.settings.close).toHaveBeenCalled();
+    });
+
+    test('should not force-close the settings window if show-settings reopens it before the delay elapses', () => {
+      setupIpcHandlers(mockWindows);
+
+      const closeHandler = mockIpcMain.on.mock.calls
+        .find(([event]) => event === 'close-settings')[1];
+      const showHandler = mockIpcMain.on.mock.calls
+        .find(([event]) => event === 'show-settings')[1];
+
+      closeHandler();
+      showHandler();
+
+      jest.advanceTimersByTime(500);
+
+      expect(mockWindows.settings.close).not.toHaveBeenCalled();
     });
   });
 

--- a/tests/unit/logger.test.js
+++ b/tests/unit/logger.test.js
@@ -303,6 +303,19 @@ describe('Logger', () => {
       expect(logger.maskName(undefined)).toBeUndefined();
       expect(logger.maskName(null)).toBeNull();
     });
+
+    test('maskAuthUrl masks token, code, and state query params', () => {
+      expect(logger.maskAuthUrl('toast-app://auth?code=abc123&state=xyz789')).toBe('toast-app://auth?code=***&state=***');
+      expect(logger.maskAuthUrl('https://app.toast.sh/oauth/authorize?client_id=1&state=xyz789')).toBe(
+        'https://app.toast.sh/oauth/authorize?client_id=1&state=***',
+      );
+      expect(logger.maskAuthUrl('https://app.toast.sh/callback?token=secret')).toBe('https://app.toast.sh/callback?token=***');
+    });
+
+    test('maskAuthUrl returns non-string values unchanged', () => {
+      expect(logger.maskAuthUrl(undefined)).toBeUndefined();
+      expect(logger.maskAuthUrl(null)).toBeNull();
+    });
   });
 
   describe('Module Exports', () => {

--- a/tests/unit/main-ipc.test.js
+++ b/tests/unit/main-ipc.test.js
@@ -300,6 +300,13 @@ describe('Main IPC Handlers (P0)', () => {
       expect(result).toBe(true);
     });
 
+    test('should re-register the global hotkey after reset-config', async () => {
+      await ipcHandlers['reset-config']();
+
+      const shortcuts = require('../../src/main/shortcuts');
+      expect(shortcuts.registerGlobalShortcuts).toHaveBeenCalledWith(mockConfig, windows);
+    });
+
     test('should handle import-config requests', async () => {
       const mockEvent = {};
       const filePath = '/path/to/config.json';
@@ -309,6 +316,16 @@ describe('Main IPC Handlers (P0)', () => {
       const config = require('../../src/main/config');
       expect(config.importConfig).toHaveBeenCalled();
       expect(result).toBe(true);
+    });
+
+    test('should re-register the global hotkey after import-config', async () => {
+      const mockEvent = {};
+      const filePath = '/path/to/config.json';
+
+      await ipcHandlers['import-config'](mockEvent, filePath);
+
+      const shortcuts = require('../../src/main/shortcuts');
+      expect(shortcuts.registerGlobalShortcuts).toHaveBeenCalledWith(mockConfig, windows);
     });
 
     test('should handle export-config requests', async () => {

--- a/tests/unit/preload/settings-preload.test.js
+++ b/tests/unit/preload/settings-preload.test.js
@@ -97,11 +97,6 @@ describe('Settings Preload Script', () => {
       expect(settingsAPI.exportConfig).toBeDefined();
     });
 
-    test('should expose action methods', () => {
-      expect(settingsAPI.testAction).toBeDefined();
-      expect(settingsAPI.validateAction).toBeDefined();
-    });
-
     test('should expose dialog methods', () => {
       expect(settingsAPI.showOpenDialog).toBeDefined();
       expect(settingsAPI.showSaveDialog).toBeDefined();
@@ -211,20 +206,9 @@ describe('Settings Preload Script', () => {
   });
 
   describe('Action Functions', () => {
-    test('should call test-action with action parameter', () => {
-      const testAction = { type: 'exec', command: 'ls -la' };
-      
-      settingsAPI.testAction(testAction);
-      
-      expect(mockIpcRenderer.invoke).toHaveBeenCalledWith('test-action', testAction);
-    });
-
-    test('should call validate-action with action parameter', () => {
-      const testAction = { type: 'application', path: '/Applications/Safari.app' };
-      
-      settingsAPI.validateAction(testAction);
-      
-      expect(mockIpcRenderer.invoke).toHaveBeenCalledWith('validate-action', testAction);
+    test('should not expose action execution/testing methods, which the Settings window never uses', () => {
+      expect(settingsAPI.testAction).toBeUndefined();
+      expect(settingsAPI.validateAction).toBeUndefined();
     });
   });
 

--- a/tests/unit/updater.test.js
+++ b/tests/unit/updater.test.js
@@ -369,5 +369,28 @@ describe('Auto Updater', () => {
       expect(mockTrayModule.setUpdateState).toHaveBeenCalledWith('available', '1.1.0');
       expect(mockAutoUpdater.quitAndInstall).not.toHaveBeenCalled();
     });
+
+    test('should not revert tray state when a download is already in progress', async () => {
+      jest.useFakeTimers();
+      updater.initAutoUpdater(mockWindows);
+
+      // Never resolves, simulating a download from an earlier click still running
+      mockAutoUpdater.downloadUpdate.mockReturnValue(new Promise(() => {}));
+
+      // First click starts the real download and leaves updateDownloadInProgress set
+      const firstClick = updater.downloadAndInstallUpdate('1.1.0');
+      await jest.advanceTimersByTimeAsync(500);
+      mockTrayModule.setUpdateState.mockClear();
+
+      // Second click (e.g. a double-click) must not report failure or revert the tray
+      const result = await updater.downloadAndInstallUpdate('1.1.0');
+
+      expect(result.success).toBe(false);
+      expect(result.alreadyInProgress).toBe(true);
+      expect(mockTrayModule.setUpdateState).not.toHaveBeenCalledWith('available', '1.1.0');
+
+      // Avoid an unhandled/never-settling promise lingering after the test
+      void firstClick;
+    });
   });
 });


### PR DESCRIPTION
## Summary

Systematic domain-by-domain audit of the app (actions, auth/cloud-sync/API, config/IPC/windows, shortcuts/tray/updater/text-expander, and both renderer UIs), cross-checking the auth/sync contract against the `toast-web` server. Each finding below is an independent, minimal, tested fix — bundled into one branch/PR because they were produced together during the same audit pass, not because they share a single purpose. Happy to split into smaller PRs if preferred.

## Changes

**Actions**
- `chain.js`: a `stopOnError:false` chain reported `success:true` even when every sub-action failed, because the failure flag was only set when `stopOnError` was also true. Now tracks failure and early-stop separately, with a new `"Chain completed with one or more errors"` message for the continue-on-error-with-failures case.
- `exec.js`: `open -a "App Name"` + `workingDir` lost the quotes around an already-quoted multi-word app name, letting the shell word-split it into the wrong arguments. Fixed via a shared `quoteAppName` helper.

**Shortcuts / Windows**
- `reset-config` and `import-config` could both change `globalHotkey` but never called `registerGlobalShortcuts()` afterward, leaving the old hotkey bound (or a newly imported one inert) until restart.
- `close-settings` scheduled a `window.close()` 500ms after `hide()` with no way to cancel; reopening the settings window within that window (via `show-settings`/`show-settings-tab`) still got force-closed by the stale timeout.

**Auth**
- The token endpoint (`toast-web` `app/api/oauth/token/route.ts`) returns HTTP 400 `INVALID_GRANT` for an expired/reused/invalid refresh token; 401 `INVALID_CLIENT` is reserved for bad `client_id`/`client_secret`. The client only checked for a bare 401, so the `SESSION_EXPIRED` cleanup path was effectively unreachable for the real expired-token case, and dead tokens kept getting retried every cooldown window.
- `requireRelogin` was already being returned on session expiry but nothing consumed it — `auth-manager`'s wrapper just forwarded the result. Now it runs the full logout flow (stops cloud sync, notifies both windows) whenever a refresh comes back with `requireRelogin`.

**Security hardening**
- `action-approval.js` only gated cloud-synced `application` actions that carried launch parameters. A parameterless action pointing at any local executable (not just an installed `.app`) ran immediately with no approval prompt. Now only a parameterless launch of an actual `.app` bundle stays gate-free; anything else is gated like exec/script actions. **Behavior change:** existing cloud-synced buttons that launch a non-`.app` path without parameters will prompt for one-time approval after this ships.
- Removed `testAction`/`validateAction` from the Settings window's preload — they bridge directly to `test-action`/`validate-action`, which execute arbitrary exec/script/application actions with no approval gate, and nothing in the Settings UI ever called them (action editing/testing lives in the toast popup, which doesn't expose them either).
- Replaced two `innerHTML` assignments of user/server-derived text (an update-error message, and profile-avatar initials) with `textContent`/DOM-node construction.
- Removed the hardcoded CSRF-state `encryptionKey` (a literal in source gives no real confidentiality) and extended `maskAuthUrl` to mask the `state` query param, not just `token`/`code`.

**Settings window**
- `index.js` only listened for the one-shot `config-loaded` event; it never handled `config-updated`, which is broadcast after every config write including the automatic 15-minute cloud sync merge. The Snippets tab snapshots `config.snippets` into local state at tab-init and persists the full array on every edit, so a background merge landing while the window was open was silently discarded on the next snippet add/edit/delete.

**Updater / Toast popup**
- `downloadAndInstallUpdate` treated `downloadUpdate()`'s "already in progress" guard the same as a real failure, reverting the tray to `available` on a double-click even though the original download was still running.
- `enableButtonDrag` leaked a pair of `document`-level `mousemove`/`mouseup` listeners and an orphaned `.drag-ghost` node whenever the toast window hid mid-drag (blur, global hotkey, Escape) instead of via `mouseup`. Hooked the existing `before-window-hide` event (already used by `keyboard.js` for the same class of mid-interaction cleanup).

**Docs**
- `cloud-sync.md` still described tokens as `safeStorage`/Keychain-encrypted with plaintext only as a fallback, contradicting `security.md` and the actual behavior since commits `98e087a`/`0443525` (plaintext + 0600, legacy encrypted files migrated on read).

## Test Plan
- [x] `npm run lint` — 0 errors (16 pre-existing warnings, unrelated to this diff)
- [x] `npm test` — 35 suites / 1040 tests passing, including new/updated regression tests for every fix above with main-process test coverage (chain, exec, shortcuts re-registration, settings-window race via fake timers, auth refresh contract, auth-manager logout wiring, action-approval fingerprinting, updater double-click, logger masking)
- [ ] Manual verification in the running app — the renderer-only changes (`settings/index.js`, `toast/modules/buttons.js`, `toast/modules/auth.js`, `about-settings.js`) have no unit test coverage in this project (no renderer test infra exists yet), so they're covered by code review + the reasoning above rather than automated tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **개선 사항**
  * 체인 작업의 중단/에러 동반 완료 여부에 따라 상태와 안내 메시지가 더 정확해졌습니다.
  * 클라우드 동기화 시 앱 실행 판정과 “스니펫” 설정 반영이 더 정교해졌습니다.
  * 로그인 후/설정 초기화·가져오기 후 전역 단축키가 즉시 재적용됩니다.
  * 설정 창 빠른 닫기·재열기 시 예기치 않은 닫힘과 드래그 중 이슈가 줄었습니다.
  * 업데이트 다운로드 중복 실행 시 트레이 상태 되돌림이 방지됩니다.
* **보안**
  * 인증 URL 로그에서 토큰·코드·상태가 추가로 마스킹됩니다.
  * 세션 만료 감지 시 자동 로그아웃 처리가 강화되었습니다.
* **문서**
  * 체인 액션 예시 반환 설명과 클라우드 동기화 토큰 저장 안내가 업데이트되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->