### PR TITLE
fix(auth): harden login/logout and cloud-sync against race conditions

### DIFF
--- a/src/main/api/auth.js
+++ b/src/main/api/auth.js
@@ -424,10 +424,8 @@ async function handleAuthRedirect({ url, onCodeExchange }) {
       };
     }
 
-    // Validate state value (CSRF prevention)
-    const storedState = retrieveStoredState();
-    if (!storedState || state !== storedState) {
-      logger.error('State mismatch. Possible CSRF attack');
+    // Validate state value (CSRF prevention) and consume it so it cannot be replayed
+    if (!validateStateParam(state)) {
       setLoginInProgress(false); // Reset login state
       return {
         success: false,

--- a/src/main/api/client.js
+++ b/src/main/api/client.js
@@ -151,16 +151,25 @@ async function authenticatedRequest(apiCall, options = {}) {
       const timeSinceLastRefresh = now - tokenRefreshTracking.lastRefreshTime;
 
       if (timeSinceLastRefresh < tokenRefreshTracking.refreshCooldownMs) {
-        if (allowUnauthenticated && defaultValue) {
-          return defaultValue;
+        // Another concurrent request may have already refreshed the token within this
+        // cooldown window, so retry with the current token before falling back — otherwise
+        // a valid session gets treated as unauthenticated just because a sibling request
+        // happened to refresh moments earlier.
+        try {
+          return await apiCall();
         }
+        catch (retryError) {
+          if (allowUnauthenticated && defaultValue) {
+            return defaultValue;
+          }
 
-        return {
-          error: {
-            code: 'AUTH_REFRESH_RATE_LIMIT',
-            message: 'Authentication refresh rate limit exceeded. Please try again later.',
-          },
-        };
+          return {
+            error: {
+              code: 'AUTH_REFRESH_RATE_LIMIT',
+              message: 'Authentication refresh rate limit exceeded. Please try again later.',
+            },
+          };
+        }
       }
 
       if (tokenRefreshTracking.requestsAfterRefresh >= tokenRefreshTracking.maxRequestsAfterRefresh) {

--- a/src/main/api/client.js
+++ b/src/main/api/client.js
@@ -247,8 +247,10 @@ async function authenticatedRequest(apiCall, options = {}) {
             }
           }
         }
-        else {
-          // Reset tokens on refresh failure
+        else if (refreshResult && refreshResult.requireRelogin) {
+          // The refresh callback identified the session itself as dead (e.g. the refresh
+          // token was rejected as expired/invalid) — reset tokens so the app doesn't keep
+          // retrying with credentials that can never succeed again.
           clearTokens();
 
           if (isSubscriptionRequest) {
@@ -260,6 +262,26 @@ async function authenticatedRequest(apiCall, options = {}) {
               code: 'AUTH_REFRESH_FAILED',
               message: 'Failed to refresh authentication. Please log in again.',
               requireRelogin: true,
+            },
+          };
+        }
+        else {
+          // Refresh failed for a transient reason (network error, server error, missing
+          // credentials, ...) rather than a dead session — keep the existing tokens so a
+          // later attempt can still succeed, instead of forcing a full logout.
+          if (allowUnauthenticated && defaultValue) {
+            return defaultValue;
+          }
+
+          if (isSubscriptionRequest) {
+            return defaultSubscription;
+          }
+
+          return {
+            error: {
+              code: 'AUTH_REFRESH_FAILED',
+              message: 'Failed to refresh authentication. Please try again later.',
+              requireRelogin: false,
             },
           };
         }

--- a/src/main/auth-manager.js
+++ b/src/main/auth-manager.js
@@ -28,6 +28,15 @@ let syncManager = null;
 // since happened and skip sending a now-stale notification.
 let authSequence = 0;
 
+// A dead session can be discovered through more than one path at once — e.g. auth.js's
+// own session-expired handler (fire-and-forget) and this module's requireRelogin checks
+// in refreshAccessToken/fetchUserProfile/fetchSubscription all call logout() for the same
+// underlying event. Sharing one in-flight promise (mirrors auth.js's refreshPromise dedup)
+// keeps logout() safe to call from all of them without revoking the token or notifying
+// both windows more than once per actual logout.
+let isLoggingOut = false;
+let logoutPromise = null;
+
 /**
  * Set up cloud synchronization manager
  * @param {Object} syncMgr - Synchronization manager instance
@@ -303,65 +312,83 @@ async function exchangeCodeForTokenAndUpdateSubscription(code) {
  * @returns {Promise<boolean>} Whether logout was successful
  */
 async function logout() {
+  // Another trigger (e.g. auth.js's session-expired handler) already has a logout in
+  // flight — share its result instead of running the whole flow (server revoke, user data
+  // cleanup, window notifications) a second time for the same underlying event.
+  if (isLoggingOut && logoutPromise) {
+    logger.info('Logout already in progress; sharing in-flight result');
+    return logoutPromise;
+  }
+
+  isLoggingOut = true;
   authSequence += 1;
-  try {
-    logger.info('Starting logout process');
-    const result = await auth.logout();
 
-    // Stop periodic synchronization and update cloud sync settings when logout is successful
-    if (result && syncManager) {
-      // Disable synchronization feature and stop periodic synchronization
-      if (typeof syncManager.updateCloudSyncSettings === 'function') {
-        syncManager.updateCloudSyncSettings(false);
+  logoutPromise = (async () => {
+    try {
+      logger.info('Starting logout process');
+      const result = await auth.logout();
+
+      // Stop periodic synchronization and update cloud sync settings when logout is successful
+      if (result && syncManager) {
+        // Disable synchronization feature and stop periodic synchronization
+        if (typeof syncManager.updateCloudSyncSettings === 'function') {
+          syncManager.updateCloudSyncSettings(false);
+        }
+        if (typeof syncManager.stopPeriodicSync === 'function') {
+          syncManager.stopPeriodicSync();
+        }
+
+        logger.info('Cloud synchronization disabled and periodic synchronization stopped due to logout');
       }
-      if (typeof syncManager.stopPeriodicSync === 'function') {
-        syncManager.stopPeriodicSync();
+
+      // Clean up user data when logout is successful
+      if (result) {
+        userDataManager.cleanupOnLogout();
+        logger.info('User data cleanup completed due to logout');
+
+        // Get current configuration
+        const config = createConfigStore();
+
+        // Reset subscription information only. pages/appearance/advanced are left untouched —
+        // they are the user's actual content and this device may hold the only unsynced copy
+        // (offline edits, sync disabled, or the upload debounce hadn't fired). Deleting them
+        // locally on logout is unrecoverable if the copy was never uploaded.
+        config.set('subscription', {
+          isAuthenticated: false,
+          isSubscribed: false,
+          expiresAt: '',
+          pageGroups: PAGE_GROUPS.ANONYMOUS, // Reset to anonymous user default
+        });
+
+        logger.info('Subscription reset to anonymous defaults on logout');
+
+        // Send app authentication state change notification
+        notifyAuthStateChange({
+          isAuthenticated: false,
+          profile: DEFAULT_ANONYMOUS,
+          settings: null,
+        });
+        logger.info('Authentication state change notification sent');
       }
 
-      logger.info('Cloud synchronization disabled and periodic synchronization stopped due to logout');
+      // Send notification to both windows when logout is successful
+      if (result) {
+        notifyLogout();
+      }
+
+      return result;
     }
-
-    // Clean up user data when logout is successful
-    if (result) {
-      userDataManager.cleanupOnLogout();
-      logger.info('User data cleanup completed due to logout');
-
-      // Get current configuration
-      const config = createConfigStore();
-
-      // Reset subscription information only. pages/appearance/advanced are left untouched —
-      // they are the user's actual content and this device may hold the only unsynced copy
-      // (offline edits, sync disabled, or the upload debounce hadn't fired). Deleting them
-      // locally on logout is unrecoverable if the copy was never uploaded.
-      config.set('subscription', {
-        isAuthenticated: false,
-        isSubscribed: false,
-        expiresAt: '',
-        pageGroups: PAGE_GROUPS.ANONYMOUS, // Reset to anonymous user default
-      });
-
-      logger.info('Subscription reset to anonymous defaults on logout');
-
-      // Send app authentication state change notification
-      notifyAuthStateChange({
-        isAuthenticated: false,
-        profile: DEFAULT_ANONYMOUS,
-        settings: null,
-      });
-      logger.info('Authentication state change notification sent');
+    catch (error) {
+      logger.error('Error logging out:', error);
+      return false;
     }
-
-    // Send notification to both windows when logout is successful
-    if (result) {
-      notifyLogout();
+    finally {
+      isLoggingOut = false;
+      logoutPromise = null;
     }
+  })();
 
-    return result;
-  }
-  catch (error) {
-    logger.error('Error logging out:', error);
-    return false;
-  }
+  return logoutPromise;
 }
 
 /**

--- a/src/main/auth-manager.js
+++ b/src/main/auth-manager.js
@@ -347,7 +347,17 @@ async function fetchUserProfile(forceRefresh = false) {
     return storedProfile;
   }
 
-  return await auth.fetchUserProfile();
+  const profileData = await auth.fetchUserProfile();
+
+  // A dead session surfaces here as an error with requireRelogin (auth.js's own
+  // refreshAccessToken only clears the local token file, it doesn't run the full
+  // app-level logout), so run it here instead of leaving the app in a stale
+  // "logged in" state.
+  if (profileData?.error?.requireRelogin) {
+    await logout();
+  }
+
+  return profileData;
 }
 
 /**
@@ -364,6 +374,11 @@ async function fetchSubscription(forceRefresh = false) {
 
   // Call API if no stored information or force refresh
   const profileData = await auth.fetchUserProfile();
+
+  // See fetchUserProfile() above for why this needs to run the full logout.
+  if (profileData?.error?.requireRelogin) {
+    await logout();
+  }
 
   if (profileData && profileData.subscription) {
     // Successfully retrieved profile data with subscription information

--- a/src/main/auth-manager.js
+++ b/src/main/auth-manager.js
@@ -23,6 +23,11 @@ let windows = null;
 // Cloud synchronization object
 let syncManager = null;
 
+// Incremented on every login/logout so a background task started by one (e.g. the
+// fire-and-forget post-login sync below) can tell whether a more recent auth event has
+// since happened and skip sending a now-stale notification.
+let authSequence = 0;
+
 /**
  * Set up cloud synchronization manager
  * @param {Object} syncMgr - Synchronization manager instance
@@ -46,6 +51,11 @@ function initialize(windowsRef) {
     fetchUserProfile: () => auth.fetchUserProfile(),
     fetchSubscription: () => auth.fetchSubscription(),
   });
+
+  // Run the full app-level logout when auth.js detects a dead session on its own (e.g.
+  // hasValidToken's automatic refresh), not just when profile/subscription fetch or an
+  // explicit refresh call surfaces requireRelogin.
+  auth.setSessionExpiredHandler(() => logout());
 }
 
 /**
@@ -87,6 +97,8 @@ async function exchangeCodeForToken(code) {
  * @returns {Promise<Object>} Processing result
  */
 async function exchangeCodeForTokenAndUpdateSubscription(code) {
+  authSequence += 1;
+  const mySequence = authSequence;
   try {
     logger.info('Starting exchange of authentication code for token and update of profile/settings');
     const result = await auth.exchangeCodeForTokenAndUpdateSubscription(code);
@@ -209,6 +221,14 @@ async function exchangeCodeForTokenAndUpdateSubscription(code) {
             logger.info('User settings saved successfully');
           }
 
+          // A logout (or a newer login) may have happened while the settings fetch above
+          // was in flight — notifying now would flip the UI back to "logged in" over a
+          // logout that already ran, and re-run sync against a session that no longer exists.
+          if (mySequence !== authSequence) {
+            logger.info('Newer auth event occurred during post-login sync; skipping stale notification');
+            return false;
+          }
+
           // Send authentication state change notification (including profile and settings)
           notifyAuthStateChange({
             isAuthenticated: true,
@@ -275,6 +295,7 @@ async function exchangeCodeForTokenAndUpdateSubscription(code) {
  * @returns {Promise<boolean>} Whether logout was successful
  */
 async function logout() {
+  authSequence += 1;
   try {
     logger.info('Starting logout process');
     const result = await auth.logout();

--- a/src/main/auth-manager.js
+++ b/src/main/auth-manager.js
@@ -115,6 +115,14 @@ async function exchangeCodeForTokenAndUpdateSubscription(code) {
         await userDataManager.getUserProfile(true, userProfile);
       }
 
+      // A logout (or a newer login) may have completed while the network calls above were
+      // in flight. Continuing would resurrect authenticated state — the notification below,
+      // and the ConfigStore write further down — over a logout that already ran.
+      if (mySequence !== authSequence) {
+        logger.info('Newer auth event occurred during login continuation; aborting stale login flow');
+        return { success: false, error: 'Logged out during login' };
+      }
+
       // Notify both windows on login success (profile cache is now warm)
       notifyLoginSuccess(result.subscription);
 

--- a/src/main/auth-manager.js
+++ b/src/main/auth-manager.js
@@ -12,7 +12,7 @@ const userDataManager = require('./user-data-manager');
 
 // Create logger for this module
 const logger = createLogger('AuthManager');
-const { createConfigStore, markAsSynced } = require('./config');
+const { createConfigStore } = require('./config');
 const client = require('./api/client');
 const { DEFAULT_ANONYMOUS_SUBSCRIPTION, DEFAULT_ANONYMOUS, PAGE_GROUPS } = require('./constants');
 const { determineCloudSyncFeature, normalizeExpiryString, calculatePageGroups, isSubscriptionActive } = require('./subscription');
@@ -300,7 +300,10 @@ async function logout() {
       // Get current configuration
       const config = createConfigStore();
 
-      // Reset subscription information and clear all settings
+      // Reset subscription information only. pages/appearance/advanced are left untouched —
+      // they are the user's actual content and this device may hold the only unsynced copy
+      // (offline edits, sync disabled, or the upload debounce hadn't fired). Deleting them
+      // locally on logout is unrecoverable if the copy was never uploaded.
       config.set('subscription', {
         isAuthenticated: false,
         isSubscribed: false,
@@ -308,28 +311,7 @@ async function logout() {
         pageGroups: PAGE_GROUPS.ANONYMOUS, // Reset to anonymous user default
       });
 
-      // Trim pages down to the anonymous entitlement instead of wiping them:
-      // this may be the only copy of the user's data if it was never synced
-      // (offline edits, sync disabled, or the upload debounce hadn't fired).
-      const currentPages = config.get('pages');
-      config.set('pages', Array.isArray(currentPages) ? currentPages.slice(0, PAGE_GROUPS.ANONYMOUS) : []);
-
-      // Reset appearance to default
-      config.set('appearance', {});
-
-      // Reset advanced settings to default
-      config.set('advanced', {});
-
-      // Sync is disabled by this point (updateCloudSyncSettings(false) above), so the
-      // 'pages' write above never reached handleConfigChange's markAsModified() call —
-      // the _sync hash/timestamps are still whatever the logged-out user last synced.
-      // Left stale, the next person to log in on this device would have their sync
-      // treat this leftover local page as "unsynced changes" and upload/merge it into
-      // their own account. Mark the post-logout state as synced so it reads as current,
-      // not as changes belonging to whoever logs in next.
-      markAsSynced(config);
-
-      logger.info('All user configuration reset to defaults on logout');
+      logger.info('Subscription reset to anonymous defaults on logout');
 
       // Send app authentication state change notification
       notifyAuthStateChange({

--- a/src/main/auth.js
+++ b/src/main/auth.js
@@ -551,6 +551,19 @@ let lastTokenRefresh = 0;
 let isRefreshing = false;
 let refreshPromise = null;
 
+// Invoked when a refresh discovers the session itself is dead (SESSION_EXPIRED), so callers
+// that reach refreshAccessToken outside auth-manager's own requireRelogin checks (e.g.
+// hasValidToken's automatic refresh) still trigger a full app-level logout instead of
+// silently leaving the app in a stale "logged in" state.
+let sessionExpiredHandler = null;
+function setSessionExpiredHandler(fn) {
+  sessionExpiredHandler = fn;
+}
+
+// Timestamp of the most recent logout() call, used to detect a refresh that was already
+// in flight when logout() ran (see the storeTokens guard below).
+let lastLogoutAt = 0;
+
 /**
  * Get new access token using refresh token
  * @returns {Promise<object>} Token refresh result (success: boolean, error?: string)
@@ -558,6 +571,14 @@ let refreshPromise = null;
 async function refreshAccessToken() {
   try {
     logger.info('Starting token refresh process');
+
+    // If already refreshing, return the ongoing refresh promise instead of starting a new
+    // one. Checked before the throttle window below so a second caller sharing the same
+    // in-flight refresh isn't misrouted into REFRESH_THROTTLED.
+    if (isRefreshing && refreshPromise) {
+      logger.info('Token refresh already in progress. Returning existing promise to prevent duplicate requests.');
+      return refreshPromise;
+    }
 
     // Throttling: Skip if not enough time has passed since last refresh request
     const now = Date.now();
@@ -585,15 +606,10 @@ async function refreshAccessToken() {
       }
     }
 
-    // If already refreshing, return the ongoing refresh promise instead of starting a new one
-    if (isRefreshing && refreshPromise) {
-      logger.info('Token refresh already in progress. Returning existing promise to prevent duplicate requests.');
-      return refreshPromise;
-    }
-
     // Set refresh state and create a promise that will be shared across concurrent calls
     isRefreshing = true;
     lastTokenRefresh = now;
+    const refreshStartedAt = now;
 
     // Create a new shared promise for this refresh operation
     refreshPromise = (async () => {
@@ -648,6 +664,15 @@ async function refreshAccessToken() {
             // Delete local token file
             await clearLocalTokenStorage();
             logger.info('Expired tokens reset complete');
+
+            // Notify the app-level logout handler so callers that reach this refresh
+            // directly (e.g. hasValidToken) also stop cloud sync and update the UI,
+            // instead of only clearing local token storage.
+            if (sessionExpiredHandler) {
+              Promise.resolve(sessionExpiredHandler()).catch(handlerError => {
+                logger.error('Session-expired handler failed:', handlerError);
+              });
+            }
           }
 
           // Only a successful refresh should start the cooldown — leaving it set after a
@@ -658,7 +683,20 @@ async function refreshAccessToken() {
           return refreshResult;
         }
 
-        // On success, store new tokens
+        // On success, store new tokens — unless logout() ran at or after this refresh
+        // started (>=, not >: Date.now() has only millisecond resolution, so a logout
+        // landing in the same tick as the refresh start must still win), in which case
+        // the token file was already deleted and this response's rotated token was never
+        // revoked; writing it back would silently undo the logout.
+        if (lastLogoutAt >= refreshStartedAt) {
+          logger.warn('Logout occurred during token refresh; discarding refreshed tokens');
+          return {
+            success: false,
+            error: 'Logged out during token refresh',
+            code: 'LOGGED_OUT_DURING_REFRESH',
+          };
+        }
+
         const { access_token, refresh_token, expires_in } = refreshResult;
 
         const tokenExpiresIn = resolveExpiresIn(expires_in);
@@ -706,6 +744,10 @@ async function refreshAccessToken() {
  */
 async function logout() {
   try {
+    // Recorded before anything else so a refresh already in flight can tell it started
+    // before this logout and must not resurrect the token file it's about to delete.
+    lastLogoutAt = Date.now();
+
     // Revoke the refresh token on the server before deleting it locally, so
     // it cannot be used to mint new access tokens after logout.
     const refreshToken = await getStoredRefreshToken();
@@ -979,4 +1021,5 @@ module.exports = {
   getAccessToken,
   updatePageGroupSettings,
   refreshAccessToken,
+  setSessionExpiredHandler,
 };

--- a/src/main/auth.js
+++ b/src/main/auth.js
@@ -644,6 +644,11 @@ async function refreshAccessToken() {
             logger.info('Expired tokens reset complete');
           }
 
+          // Only a successful refresh should start the cooldown — leaving it set after a
+          // failure (e.g. a transient network error) would lock out retries for the full
+          // cooldown window even though the very next attempt might succeed.
+          lastTokenRefresh = 0;
+
           return refreshResult;
         }
 
@@ -658,6 +663,7 @@ async function refreshAccessToken() {
       }
       catch (error) {
         logger.error('Exception in token refresh:', error);
+        lastTokenRefresh = 0;
         return {
           success: false,
           error: error.message || 'Unknown error in token refresh',

--- a/src/main/auth.js
+++ b/src/main/auth.js
@@ -402,13 +402,11 @@ async function handleAuthRedirect(url) {
       if (hasToken) {
         // If already authenticated, just refresh subscription information
         logger.info('Already authenticated, refreshing subscription info');
-        const subscription = await fetchSubscription();
-        await updatePageGroupSettings(subscription);
+        const refreshResult = await refreshSubscriptionSettings();
 
         return {
-          success: true,
-          message: 'Authentication refreshed',
-          subscription,
+          ...refreshResult,
+          message: refreshResult.success ? 'Authentication refreshed' : undefined,
         };
       }
       else {
@@ -449,13 +447,11 @@ async function handleAuthRedirect(url) {
         if (hasToken) {
           // If already authenticated, just refresh subscription information
           logger.info('Already authenticated, refreshing subscription info');
-          const subscription = await fetchSubscription();
-          await updatePageGroupSettings(subscription);
+          const refreshResult = await refreshSubscriptionSettings();
 
           return {
-            success: true,
-            message: 'Authentication refreshed',
-            subscription,
+            ...refreshResult,
+            message: refreshResult.success ? 'Authentication refreshed' : undefined,
           };
         }
         else {
@@ -492,6 +488,11 @@ async function handleAuthRedirect(url) {
  */
 async function exchangeCodeForToken(code) {
   try {
+    if (isLoggingOut) {
+      logger.info('Logout in progress; aborting code exchange');
+      return { success: false, error: 'Logout in progress' };
+    }
+
     // Verify OAuth credentials are configured
     if (!CLIENT_ID || !CLIENT_SECRET) {
       logger.error('OAuth credentials are not configured. Please set CLIENT_ID and CLIENT_SECRET in environment variables or .env file.');
@@ -503,6 +504,8 @@ async function exchangeCodeForToken(code) {
 
     logger.info('Starting exchange of authentication code for token:', code.substring(0, 8) + '...');
 
+    const exchangeStartGeneration = logoutGeneration;
+
     // Exchange code for token through common module
     const tokenResult = await apiAuth.exchangeCodeForToken({
       code,
@@ -512,6 +515,14 @@ async function exchangeCodeForToken(code) {
 
     if (!tokenResult.success) {
       return tokenResult;
+    }
+
+    // A logout may have completed while the exchange above was in flight — storing these
+    // tokens now would resurrect a session the user just ended (and this refresh token,
+    // issued after logout's revoke call, was never revoked on the server).
+    if (logoutGeneration !== exchangeStartGeneration) {
+      logger.warn('Logout occurred during code exchange; discarding issued tokens');
+      return { success: false, error: 'Logged out during authentication' };
     }
 
     // Store tokens
@@ -560,9 +571,16 @@ function setSessionExpiredHandler(fn) {
   sessionExpiredHandler = fn;
 }
 
-// Timestamp of the most recent logout() call, used to detect a refresh that was already
-// in flight when logout() ran (see the storeTokens guard below).
-let lastLogoutAt = 0;
+// True for the duration of logout() (from the moment it's called until it fully
+// completes), so a refresh that would otherwise start mid-logout is stopped before it
+// ever contacts the server — see the early guard below.
+let isLoggingOut = false;
+
+// Incremented when logout() actually deletes the local token file, so a refresh that was
+// already in flight *before* logout began (and therefore passed the isLoggingOut guard
+// above) can still detect — right before it would persist new tokens — that a logout has
+// since completed, and avoid resurrecting the file logout just deleted.
+let logoutGeneration = 0;
 
 /**
  * Get new access token using refresh token
@@ -571,6 +589,11 @@ let lastLogoutAt = 0;
 async function refreshAccessToken() {
   try {
     logger.info('Starting token refresh process');
+
+    if (isLoggingOut) {
+      logger.info('Logout in progress; skipping token refresh');
+      return { success: false, error: 'Logout in progress', code: 'LOGOUT_IN_PROGRESS' };
+    }
 
     // If already refreshing, return the ongoing refresh promise instead of starting a new
     // one. Checked before the throttle window below so a second caller sharing the same
@@ -609,7 +632,7 @@ async function refreshAccessToken() {
     // Set refresh state and create a promise that will be shared across concurrent calls
     isRefreshing = true;
     lastTokenRefresh = now;
-    const refreshStartedAt = now;
+    const refreshStartGeneration = logoutGeneration;
 
     // Create a new shared promise for this refresh operation
     refreshPromise = (async () => {
@@ -683,12 +706,14 @@ async function refreshAccessToken() {
           return refreshResult;
         }
 
-        // On success, store new tokens — unless logout() ran at or after this refresh
-        // started (>=, not >: Date.now() has only millisecond resolution, so a logout
-        // landing in the same tick as the refresh start must still win), in which case
-        // the token file was already deleted and this response's rotated token was never
-        // revoked; writing it back would silently undo the logout.
-        if (lastLogoutAt >= refreshStartedAt) {
+        // On success, store new tokens — unless a logout completed while this refresh was
+        // in flight, in which case the token file was already deleted and this response's
+        // rotated token was never revoked; writing it back would silently undo the logout.
+        // Comparing generations (bumped only when logout actually deletes the file) rather
+        // than timestamps correctly catches this regardless of which of the two started
+        // first — a start-time comparison would miss a logout that began before this
+        // refresh but finished after it.
+        if (logoutGeneration !== refreshStartGeneration) {
           logger.warn('Logout occurred during token refresh; discarding refreshed tokens');
           return {
             success: false,
@@ -743,11 +768,10 @@ async function refreshAccessToken() {
  * @returns {Promise<boolean>} Whether logout was successful
  */
 async function logout() {
+  // Set synchronously, before any await, so a refreshAccessToken() call made anywhere
+  // in this logout's duration is stopped by the early guard instead of racing it.
+  isLoggingOut = true;
   try {
-    // Recorded before anything else so a refresh already in flight can tell it started
-    // before this logout and must not resurrect the token file it's about to delete.
-    lastLogoutAt = Date.now();
-
     // Revoke the refresh token on the server before deleting it locally, so
     // it cannot be used to mint new access tokens after logout.
     const refreshToken = await getStoredRefreshToken();
@@ -768,6 +792,11 @@ async function logout() {
       logger.info('Local token file deleted successfully');
     }
 
+    // Local token state is now finalized as logged-out; bump the generation so a refresh
+    // that was already in flight before this logout began (and so passed the early guard)
+    // discards its result instead of resurrecting the file just deleted above.
+    logoutGeneration += 1;
+
     // Reset page group settings
     const config = createConfigStore();
     config.set('subscription', {
@@ -784,6 +813,9 @@ async function logout() {
   catch (error) {
     logger.error('Logout error:', error);
     return false;
+  }
+  finally {
+    isLoggingOut = false;
   }
 }
 
@@ -821,15 +853,15 @@ async function exchangeCodeForTokenAndUpdateSubscription(code) {
 
     // Get subscription information
     try {
-      const subscription = await fetchSubscription();
+      const result = await refreshSubscriptionSettings();
+      if (!result.success) {
+        return result;
+      }
       logger.info('Successfully retrieved subscription information');
-
-      // Save subscription information to config
-      await updatePageGroupSettings(subscription);
 
       return {
         success: true,
-        subscription,
+        subscription: result.subscription,
       };
     }
     catch (subError) {
@@ -971,6 +1003,25 @@ async function updatePageGroupSettings(subscription) {
     logger.error('Error updating page group settings:', error);
     throw error;
   }
+}
+
+/**
+ * Fetch the latest subscription and persist it as an authenticated ConfigStore write —
+ * unless a logout completed while the fetch was in flight, in which case the write is
+ * skipped so it can't resurrect config state the logout just reset to anonymous.
+ * @returns {Promise<{success: boolean, subscription?: object, error?: string}>}
+ */
+async function refreshSubscriptionSettings() {
+  const startGeneration = logoutGeneration;
+  const subscription = await fetchSubscription();
+
+  if (logoutGeneration !== startGeneration) {
+    logger.warn('Logout occurred during subscription fetch; discarding subscription update');
+    return { success: false, error: 'Logged out during authentication' };
+  }
+
+  await updatePageGroupSettings(subscription);
+  return { success: true, subscription };
 }
 
 // Initialization: Load stored tokens into memory

--- a/src/main/auth.js
+++ b/src/main/auth.js
@@ -1020,6 +1020,14 @@ async function refreshSubscriptionSettings() {
     return { success: false, error: 'Logged out during authentication' };
   }
 
+  // fetchSubscription() returns the error-shaped profileData as-is on failure (see its
+  // own else-if branch below), not a subscription object — writing it through as if it
+  // were one would mark the config authenticated despite the fetch having failed.
+  if (!subscription || subscription.error) {
+    logger.error('Failed to retrieve subscription information:', subscription?.error);
+    return { success: false, error: subscription?.error?.message || 'Failed to retrieve subscription information' };
+  }
+
   await updatePageGroupSettings(subscription);
   return { success: true, subscription };
 }

--- a/src/main/auth.js
+++ b/src/main/auth.js
@@ -414,7 +414,10 @@ async function handleAuthRedirect(url) {
       else {
         // If not authenticated, start login process
         logger.info('Not authenticated, initiating login process');
-        return await initiateLogin();
+        // initiateLogin() resolves to a boolean, but handleAuthRedirect's contract
+        // (and its caller's result.success check) expects an object.
+        const started = await initiateLogin();
+        return { success: started };
       }
     }
 
@@ -458,7 +461,10 @@ async function handleAuthRedirect(url) {
         else {
           // If not authenticated, start login process
           logger.info('Not authenticated, initiating login process');
-          return await initiateLogin();
+          // initiateLogin() resolves to a boolean, but handleAuthRedirect's contract
+          // (and its caller's result.success check) expects an object.
+          const started = await initiateLogin();
+          return { success: started };
         }
       }
 

--- a/src/main/cloud-sync.js
+++ b/src/main/cloud-sync.js
@@ -253,7 +253,28 @@ function scheduleRetry(failureReasonSuffix, exceededMessage) {
   else {
     logger.error(exceededMessage);
     state.retryCount = 0;
+    // pendingSync is left untouched: only uploadSettingsWithRetry's finally block clears
+    // it, after acting on it — clearing it here would drop a change that arrived during
+    // this failed attempt without ever rescheduling it.
+  }
+}
+
+/**
+ * If a change arrived while this module was busy holding state.isSyncing (and so got
+ * marked pending instead of being scheduled directly), reschedule it now that the lock
+ * is about to be released. Must be called from every code path that can consume a
+ * pendingSync set while it was running (currently uploadSettingsWithRetry and
+ * reconcileStaleUpload), or that change is silently dropped until the next periodic sync.
+ */
+function reprocessPendingSync() {
+  if (state.pendingSync) {
+    logger.info('Processing pending sync request');
     state.pendingSync = false;
+    setTimeout(() => {
+      if (state.lastChangeType) {
+        scheduleSync(state.lastChangeType);
+      }
+    }, 1000); // Retry after 1 second
   }
 }
 
@@ -273,17 +294,20 @@ async function uploadSettingsWithRetry() {
     state.isSyncing = true;
     const result = await uploadSettings(true); // Indicate this is an internal call
 
+    // None of the branches below clear state.pendingSync — only the finally block does,
+    // after acting on it. A change that arrives mid-upload (after the snapshot in
+    // uploadSettings() was taken) sets pendingSync regardless of how this attempt
+    // resolves, and clearing it here — before finally gets to check it — would silently
+    // drop that change instead of rescheduling it.
     if (result.success) {
       logger.info(`Cloud synchronization successful for '${state.lastChangeType}' change`);
       state.retryCount = 0;
-      state.pendingSync = false;
       state.lastChangeHash = null; // Reset hash on success
     }
     else if (result.skipped) {
       // Skipped because there are no pages to upload (empty pages guard) — not a failure, so no retry
       logger.info('Upload skipped (no page data); not retrying');
       state.retryCount = 0;
-      state.pendingSync = false;
       state.lastChangeHash = null;
     }
     else if (result.statusCode === 409) {
@@ -291,7 +315,6 @@ async function uploadSettingsWithRetry() {
       // overwrite and lose local changes, so reconcile via the merge path (resolve) to preserve them
       logger.warn('Upload rejected as stale (409); scheduling conflict resolution to preserve local changes');
       state.retryCount = 0;
-      state.pendingSync = false;
       state.lastChangeHash = null;
       // Schedule the merge reconciliation to run after isSyncing is released (finally).
       // Use a reconcile slot separate from the retry slot so they don't overwrite each other.
@@ -307,7 +330,6 @@ async function uploadSettingsWithRetry() {
       // Payload validation failed — retrying would fail identically, so stop
       logger.error(`Upload rejected as invalid (400), not retrying: ${result.error}`);
       state.retryCount = 0;
-      state.pendingSync = false;
       state.lastChangeHash = null;
     }
     else {
@@ -321,17 +343,7 @@ async function uploadSettingsWithRetry() {
   }
   finally {
     state.isSyncing = false;
-
-    // Process any pending sync
-    if (state.pendingSync) {
-      logger.info('Processing pending sync request');
-      state.pendingSync = false;
-      setTimeout(() => {
-        if (state.lastChangeType) {
-          scheduleSync(state.lastChangeType);
-        }
-      }, 1000); // Retry after 1 second
-    }
+    reprocessPendingSync();
   }
 }
 
@@ -753,6 +765,7 @@ async function reconcileStaleUpload() {
   }
   finally {
     state.isSyncing = false;
+    reprocessPendingSync();
   }
 }
 

--- a/src/main/cloud-sync.js
+++ b/src/main/cloud-sync.js
@@ -195,9 +195,13 @@ function scheduleSync(changeType) {
     return;
   }
 
-  // Completely ignore if sync is currently in progress (do not wait)
+  // A sync is already in progress; a new upload can't start concurrently, so remember
+  // that another change arrived. uploadSettingsWithRetry's finally block re-schedules a
+  // sync via state.pendingSync once the in-flight one finishes, so this change isn't lost.
   if (state.isSyncing) {
-    logger.info(`${changeType} change detected but sync in progress, ignoring request`);
+    logger.info(`${changeType} change detected but sync in progress, marking pending sync`);
+    state.pendingSync = true;
+    state.lastChangeType = changeType;
     return;
   }
 
@@ -258,7 +262,10 @@ function scheduleRetry(failureReasonSuffix, exceededMessage) {
  */
 async function uploadSettingsWithRetry() {
   if (state.isSyncing) {
-    logger.info('Already syncing, request ignored');
+    // Don't drop this change: mark it pending so the finally block below re-schedules
+    // a sync once the in-flight one releases the lock (mirrors scheduleSync's guard).
+    logger.info('Already syncing, marking pending sync');
+    state.pendingSync = true;
     return;
   }
 
@@ -424,8 +431,10 @@ async function uploadSettings(isInternalCall = false) {
     if (result.success) {
       state.lastSyncTime = timestamp;
 
-      // Mark sync complete in ConfigStore
-      markAsSynced(configStore);
+      // Mark sync complete using the exact snapshot that was uploaded (not whatever is
+      // in ConfigStore now), so an edit made during the network round-trip isn't
+      // mistaken for already being synced.
+      markAsSynced(configStore, null, { pages, snippets, appearance, advanced });
 
       logger.info('Settings upload successful and sync metadata updated in ConfigStore');
       return result;
@@ -526,20 +535,19 @@ async function downloadSettings() {
         configStore.set('advanced', normalized.advanced);
       }
 
-      // Apply metadata received from the server
+      // Apply metadata received from the server. markAsSynced computes dataHash from the
+      // data that was just written above, so hasUnsyncedChanges() doesn't see a stale
+      // hash and treat this download as an unsynced change on every subsequent check.
+      markAsSynced(configStore);
       if (serverMetadata) {
         updateSyncMetadata(configStore, {
-          lastSyncedAt: timestamp,
-          lastSyncedDevice: getDeviceId(),
           lastModifiedAt: serverMetadata.lastModifiedAt || timestamp,
           lastModifiedDevice: serverMetadata.lastModifiedDevice || 'server',
-          isConflicted: false,
         });
         logger.info(`Server data synced - last modified: ${new Date(serverMetadata.lastModifiedAt || timestamp).toISOString()}`);
       }
       else {
         logger.info('No server metadata found, marking as synced with current timestamp');
-        markAsSynced(configStore);
       }
     }
     finally {
@@ -602,11 +610,27 @@ async function syncSettings(action = 'resolve') {
 
       logger.info(`Local state - Modified: ${new Date(localSyncMeta.lastModifiedAt).toISOString()}, Has changes: ${hasLocalChanges}`);
 
-      // 2. Temporarily download server settings (do not save to ConfigStore)
-      const serverResult = await apiSync.downloadSettings({
-        hasValidToken: authManager.hasValidToken,
-        onUnauthorized: authManager.refreshAccessToken,
-      });
+      // 2. Temporarily download server settings (do not save to ConfigStore).
+      // Hold the cloud-sync lock for this peek even though it doesn't touch ConfigStore:
+      // api/sync.js shares one isSyncing flag between its own upload/download, so without
+      // this a debounced upload could start concurrently and fail with a spurious
+      // "Sync already in progress" instead of being deferred by scheduleSync/
+      // uploadSettingsWithRetry's own (cloud-sync-level) guard.
+      if (state.isSyncing) {
+        logger.info('Sync in progress; deferring conflict resolution');
+        return { success: false, error: 'Sync in progress' };
+      }
+      state.isSyncing = true;
+      let serverResult;
+      try {
+        serverResult = await apiSync.downloadSettings({
+          hasValidToken: authManager.hasValidToken,
+          onUnauthorized: authManager.refreshAccessToken,
+        });
+      }
+      finally {
+        state.isSyncing = false;
+      }
 
       if (!serverResult.success) {
         logger.error('Server settings download failed:', serverResult.error);
@@ -853,6 +877,11 @@ function setupConfigListeners() {
       return;
     }
 
+    // Record that content actually changed regardless of whether a sync can run right now
+    // (disabled, logged out, offline) — otherwise lastModifiedAt stays stale and a later
+    // conflict check can pick the wrong direction and overwrite this edit with server data.
+    markAsModified(configStore);
+
     // Check whether sync is possible
     if (!state.enabled) {
       logger.info('Sync disabled - state.enabled is false');
@@ -865,12 +894,6 @@ function setupConfigListeners() {
     }
 
     logger.info(`${changeType} settings change confirmed (onDidChange event fired), proceeding with sync`);
-
-    // The onDidChange event firing is evidence that a value actually changed
-    // Skip the hasUnsyncedChanges check and proceed directly with sync
-
-    // Reflect the change in ConfigStore metadata
-    markAsModified(configStore);
 
     // Schedule sync
     scheduleSync(changeType);

--- a/src/main/cloud-sync.js
+++ b/src/main/cloud-sync.js
@@ -642,6 +642,7 @@ async function syncSettings(action = 'resolve') {
       }
       finally {
         state.isSyncing = false;
+        reprocessPendingSync();
       }
 
       if (!serverResult.success) {

--- a/src/main/config.js
+++ b/src/main/config.js
@@ -617,13 +617,16 @@ function markAsModified(config, deviceId = null) {
  * Mark settings as synced
  * @param {Object} config - ConfigStore instance
  * @param {string} [deviceId] - Device identifier
+ * @param {Object} [dataOverride] - Data the hash should be computed from (e.g. an upload
+ *   snapshot taken before the network round-trip) instead of the current ConfigStore
+ *   contents, which may have changed while the request was in flight.
  */
-function markAsSynced(config, deviceId = null) {
+function markAsSynced(config, deviceId = null, dataOverride = null) {
   const timestamp = Date.now();
   const device = deviceId || getDeviceId();
 
-  // Generate hash based on current data
-  const currentData = {
+  // Generate hash based on the provided snapshot, or the current data if none was given
+  const currentData = dataOverride || {
     pages: config.get('pages'),
     snippets: config.get('snippets'),
     appearance: config.get('appearance'),

--- a/src/main/config.js
+++ b/src/main/config.js
@@ -526,6 +526,26 @@ function getDeviceId() {
 }
 
 /**
+ * Deterministically stringify a value: object keys are sorted recursively at every
+ * nesting level so semantically identical data always produces the same string,
+ * regardless of key insertion order. A plain JSON.stringify(value, arrayOfKeys) does NOT
+ * do this — when the replacer argument is an array, it is treated as a property allowlist
+ * applied at every level, so nested keys not in that array are silently stripped.
+ * @param {*} value - Value to stringify
+ * @returns {string} Deterministic JSON string
+ */
+function stableStringify(value) {
+  if (Array.isArray(value)) {
+    return `[${value.map(stableStringify).join(',')}]`;
+  }
+  if (value && typeof value === 'object') {
+    const keys = Object.keys(value).sort();
+    return `{${keys.map(key => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(',')}}`;
+  }
+  return JSON.stringify(value);
+}
+
+/**
  * Generate data hash for change detection
  * @param {Object} data - Data to hash
  * @returns {string} Hash string
@@ -539,7 +559,7 @@ function generateDataHash(data) {
     appearance: data.appearance || {},
     advanced: data.advanced || {},
   };
-  const dataString = JSON.stringify(coreData, Object.keys(coreData).sort());
+  const dataString = stableStringify(coreData);
   return crypto.createHash('sha256').update(dataString).digest('hex');
 }
 

--- a/src/main/text-expander/index.js
+++ b/src/main/text-expander/index.js
@@ -174,11 +174,21 @@ function performReplacement(match) {
     matcher.resetBuffer(bufferState);
     logger.debug(`Expanded snippet id=${match.snippet.id}`);
 
-    // Restore the previous clipboard and re-enable event handling after the
-    // synthetic paste has been delivered.
+    // Restore the previous clipboard and re-enable event handling after the synthetic
+    // paste has been delivered — but only if the clipboard still holds what we put there.
+    // If the user copied something else in the meantime, or an external tool (e.g. a
+    // password manager's auto-clear) already changed it, restoring would clobber that
+    // copy instead, or re-expose a secret the auto-clear had just wiped.
     setTimeout(() => {
-      restoreClipboard(previousClipboard);
-      injecting = false;
+      try {
+        const currentText = clipboard.availableFormats().includes('text/plain') ? clipboard.readText() : null;
+        if (currentText === match.snippet.content) {
+          restoreClipboard(previousClipboard);
+        }
+      }
+      finally {
+        injecting = false;
+      }
     }, CLIPBOARD_RESTORE_DELAY_MS);
   }
   catch (error) {

--- a/src/main/text-expander/index.js
+++ b/src/main/text-expander/index.js
@@ -186,6 +186,9 @@ function performReplacement(match) {
           restoreClipboard(previousClipboard);
         }
       }
+      catch (error) {
+        logger.error('Failed to check clipboard before restore');
+      }
       finally {
         injecting = false;
       }

--- a/src/main/text-expander/matcher.js
+++ b/src/main/text-expander/matcher.js
@@ -261,9 +261,16 @@ function validateSnippet(snippet, existing = []) {
       errors.push(`Keyword "${keyword}" is already used.`);
       continue;
     }
-    // Ambiguity: if one keyword is a suffix of the other, a buffer ending in
-    // the longer one would match both.
-    if (keyword.endsWith(otherKeyword) || otherKeyword.endsWith(keyword)) {
+    // Ambiguity: if one keyword is a suffix of the other, a buffer ending in the longer
+    // one would match both. A prefix relationship is just as ambiguous even though it
+    // doesn't share a common suffix: while typing the longer keyword, the buffer passes
+    // through a state that ends with the shorter one, which fires first and pre-empts it.
+    if (
+      keyword.endsWith(otherKeyword)
+      || otherKeyword.endsWith(keyword)
+      || keyword.startsWith(otherKeyword)
+      || otherKeyword.startsWith(keyword)
+    ) {
       errors.push(`Keyword "${keyword}" conflicts with existing keyword "${otherKeyword}".`);
     }
   }

--- a/tests/unit/api/client.test.js
+++ b/tests/unit/api/client.test.js
@@ -532,6 +532,34 @@ describe('API Client', () => {
       expect(result.error).toBeDefined();
       expect(onUnauthorized).toHaveBeenCalled();
     });
+
+    test('preserves tokens and does not require re-login on a transient refresh failure', async () => {
+      // A network error or server 500 during refresh doesn't mean the session is dead —
+      // forcing a full logout here would turn a transient blip into an unwanted sign-out.
+      client.setAccessToken('expired-token');
+      client.setRefreshToken('still-valid-refresh-token');
+      const mockApiCall = jest.fn().mockRejectedValue({ response: { status: 401 } });
+      const onUnauthorized = jest.fn().mockResolvedValue({ success: false, code: 'REFRESH_EXCEPTION' });
+
+      const result = await client.authenticatedRequest(mockApiCall, { onUnauthorized });
+
+      expect(result.error.requireRelogin).toBe(false);
+      expect(client.getAccessToken()).toBe('expired-token');
+      expect(client.getRefreshToken()).toBe('still-valid-refresh-token');
+    });
+
+    test('clears tokens and requires re-login when the refresh callback reports a dead session', async () => {
+      client.setAccessToken('expired-token');
+      client.setRefreshToken('dead-refresh-token');
+      const mockApiCall = jest.fn().mockRejectedValue({ response: { status: 401 } });
+      const onUnauthorized = jest.fn().mockResolvedValue({ success: false, code: 'SESSION_EXPIRED', requireRelogin: true });
+
+      const result = await client.authenticatedRequest(mockApiCall, { onUnauthorized });
+
+      expect(result.error.requireRelogin).toBe(true);
+      expect(client.getAccessToken()).toBeNull();
+      expect(client.getRefreshToken()).toBeNull();
+    });
   });
 
   describe('Environment Configuration', () => {

--- a/tests/unit/api/client.test.js
+++ b/tests/unit/api/client.test.js
@@ -356,6 +356,44 @@ describe('API Client', () => {
       expect(result.error.message).toContain('rate limit exceeded');
     });
 
+    test('retries the request during the refresh cooldown instead of assuming the token is still bad', async () => {
+      // A concurrent request may have already refreshed the token within the cooldown
+      // window, so a second request hitting 401 should retry with the now-current token
+      // rather than immediately falling back (e.g. to an anonymous subscription default).
+      client.setAccessToken('expired-token');
+      const onUnauthorized = jest.fn().mockResolvedValue({ success: true });
+
+      const firstApiCall = jest.fn().mockRejectedValueOnce({ response: { status: 401 } }).mockResolvedValueOnce({ data: 'first' });
+      await client.authenticatedRequest(firstApiCall, { onUnauthorized });
+
+      const secondApiCall = jest.fn().mockRejectedValueOnce({ response: { status: 401 } }).mockResolvedValueOnce({ data: 'second' });
+      const result = await client.authenticatedRequest(secondApiCall, { onUnauthorized });
+
+      expect(result).toEqual({ data: 'second' });
+      expect(secondApiCall).toHaveBeenCalledTimes(2);
+      // The cooldown must block a second refresh attempt, not trigger one
+      expect(onUnauthorized).toHaveBeenCalledTimes(1);
+    });
+
+    test('falls back to defaultValue when the cooldown retry also fails', async () => {
+      client.setAccessToken('expired-token');
+      const onUnauthorized = jest.fn().mockResolvedValue({ success: true });
+
+      const firstApiCall = jest.fn().mockRejectedValueOnce({ response: { status: 401 } }).mockResolvedValueOnce({ data: 'first' });
+      await client.authenticatedRequest(firstApiCall, { onUnauthorized });
+
+      const secondApiCall = jest.fn().mockRejectedValue({ response: { status: 401 } });
+      const defaultValue = { anonymous: true };
+      const result = await client.authenticatedRequest(secondApiCall, {
+        onUnauthorized,
+        allowUnauthenticated: true,
+        defaultValue,
+      });
+
+      expect(result).toBe(defaultValue);
+      expect(secondApiCall).toHaveBeenCalledTimes(2);
+    });
+
     test('should handle refresh loop detection', async () => {
       client.setAccessToken('expired-token');
       const mockApiCall = jest.fn().mockRejectedValue({

--- a/tests/unit/auth-manager.test.js
+++ b/tests/unit/auth-manager.test.js
@@ -15,6 +15,7 @@ const mockAuth = {
   getAccessToken: jest.fn(),
   hasValidToken: jest.fn(),
   refreshAccessToken: jest.fn(),
+  setSessionExpiredHandler: jest.fn(),
 };
 
 const mockUserDataManager = {
@@ -114,10 +115,19 @@ describe('Authentication Manager', () => {
 
     test('should handle null windows gracefully', () => {
       authManager.initialize(null);
-      
+
       // Should handle null windows and maintain functionality
       expect(typeof authManager.hasValidToken).toBe('function');
       expect(typeof authManager.notifyLoginSuccess).toBe('function');
+    });
+
+    test('registers a session-expired handler with auth.js so a dead session detected outside requireRelogin checks (e.g. hasValidToken) still triggers a full logout', async () => {
+      expect(mockAuth.setSessionExpiredHandler).toHaveBeenCalledWith(expect.any(Function));
+
+      const handler = mockAuth.setSessionExpiredHandler.mock.calls[0][0];
+      await handler();
+
+      expect(mockAuth.logout).toHaveBeenCalled();
     });
   });
 
@@ -351,6 +361,39 @@ describe('Authentication Manager', () => {
 
       expect(DEFAULT_ANONYMOUS_SUBSCRIPTION.features).toBe(sharedFeatures);
       expect(sharedFeatures.cloud_sync).toBeUndefined();
+    });
+
+    test('skips the stale post-login auth-state notification when logout runs during the background sync', async () => {
+      // exchangeCodeForTokenAndUpdateSubscription kicks off its settings sync in the
+      // background (fire-and-forget). If a logout completes before that background work
+      // finishes, its "isAuthenticated: true" notification must not overwrite the logout.
+      mockAuth.exchangeCodeForTokenAndUpdateSubscription.mockResolvedValue({
+        success: true,
+        subscription: { active: true },
+      });
+      mockAuth.fetchUserProfile.mockResolvedValue({ email: 'test@example.com' });
+
+      let resolveUserSettings;
+      mockUserDataManager.getUserSettings.mockReturnValue(
+        new Promise(resolve => {
+          resolveUserSettings = resolve;
+        }),
+      );
+
+      const loginResult = await authManager.exchangeCodeForTokenAndUpdateSubscription('test-code');
+      expect(loginResult.success).toBe(true);
+
+      // The background sync is now awaiting getUserSettings. Log out while it's pending.
+      await authManager.logout();
+      mockWindows.toast.webContents.send.mockClear();
+
+      // The background sync resumes and must see a newer auth event has happened since
+      // it started, so it must not re-announce isAuthenticated: true.
+      resolveUserSettings({ pages: [] });
+      await new Promise(resolve => setImmediate(resolve));
+
+      const authStateCalls = mockWindows.toast.webContents.send.mock.calls.filter(call => call[0] === 'auth-state-changed');
+      expect(authStateCalls).toHaveLength(0);
     });
   });
 

--- a/tests/unit/auth-manager.test.js
+++ b/tests/unit/auth-manager.test.js
@@ -177,6 +177,40 @@ describe('Authentication Manager', () => {
       expect(mockWindows.toast.webContents.send).toHaveBeenCalledWith('auth-state-changed', expect.objectContaining({ isAuthenticated: false }));
     });
 
+    test('logs out only once when the session-expired handler and the requireRelogin check both fire for the same dead session', async () => {
+      // In auth.js, a SESSION_EXPIRED refresh failure fires the session-expired handler
+      // (fire-and-forget) before returning a result with requireRelogin: true — which this
+      // module's refreshAccessToken() also checks and logs out on. Simulate both firing for
+      // the same event, as they do in the real (unmocked) auth.js. auth.logout() itself is
+      // held pending (as it would be for the real revoke-token network call's duration) so
+      // the dedup window is actually open when the second trigger checks it.
+      const sessionExpiredHandler = mockAuth.setSessionExpiredHandler.mock.calls[0][0];
+      const mockResult = {
+        success: false,
+        error: 'Your login session has expired. Please log in again.',
+        code: 'SESSION_EXPIRED',
+        requireRelogin: true,
+      };
+      let resolveAuthLogout;
+      mockAuth.logout.mockReturnValueOnce(
+        new Promise(resolve => {
+          resolveAuthLogout = resolve;
+        }),
+      );
+      mockAuth.refreshAccessToken.mockImplementation(async () => {
+        sessionExpiredHandler(); // fire-and-forget, as auth.js does internally
+        return mockResult;
+      });
+
+      const resultPromise = authManager.refreshAccessToken();
+      resolveAuthLogout(true);
+      const result = await resultPromise;
+
+      expect(result).toEqual(mockResult);
+      expect(mockAuth.logout).toHaveBeenCalledTimes(1);
+      expect(mockUserDataManager.cleanupOnLogout).toHaveBeenCalledTimes(1);
+    });
+
     test('should not log out when refresh fails for a reason other than requireRelogin', async () => {
       const mockResult = { success: false, error: 'Network error', code: 'REFRESH_FAILED' };
       mockAuth.refreshAccessToken.mockResolvedValue(mockResult);
@@ -486,6 +520,40 @@ describe('Authentication Manager', () => {
       const result = await authManager.logout();
 
       expect(result).toBe(false);
+    });
+
+    test('shares a single in-flight logout when triggered concurrently by more than one caller', async () => {
+      // A dead session can be discovered through more than one path at once — e.g. auth.js's
+      // own session-expired handler (fire-and-forget) racing with an explicit requireRelogin
+      // check in refreshAccessToken/fetchUserProfile/fetchSubscription. Both call logout()
+      // for the same underlying event; only one should actually run (server revoke, user
+      // data cleanup, window notifications), and every caller should get the same result.
+      let resolveAuthLogout;
+      mockAuth.logout.mockReturnValueOnce(
+        new Promise(resolve => {
+          resolveAuthLogout = resolve;
+        }),
+      );
+
+      const firstCall = authManager.logout();
+      const secondCall = authManager.logout();
+
+      resolveAuthLogout(true);
+      const [firstResult, secondResult] = await Promise.all([firstCall, secondCall]);
+
+      expect(mockAuth.logout).toHaveBeenCalledTimes(1);
+      expect(mockUserDataManager.cleanupOnLogout).toHaveBeenCalledTimes(1);
+      expect(firstResult).toBe(true);
+      expect(secondResult).toBe(true);
+    });
+
+    test('runs a fresh logout again after a previous one has fully completed', async () => {
+      mockAuth.logout.mockResolvedValue(true);
+
+      await authManager.logout();
+      await authManager.logout();
+
+      expect(mockAuth.logout).toHaveBeenCalledTimes(2);
     });
   });
 

--- a/tests/unit/auth-manager.test.js
+++ b/tests/unit/auth-manager.test.js
@@ -195,6 +195,19 @@ describe('Authentication Manager', () => {
 
       expect(mockUserDataManager.getUserProfile).toHaveBeenCalledWith(false);
     });
+
+    test('fully logs out when the profile fetch signals a dead session (requireRelogin)', async () => {
+      // auth.js's own refreshAccessToken (used as fetchUserProfile's onUnauthorized)
+      // only clears the local token file, it doesn't stop sync or notify the windows —
+      // that must happen here instead, or the app is left looking logged in.
+      mockUserDataManager.getUserProfile.mockResolvedValue(null); // force the cache-miss path
+      mockAuth.fetchUserProfile.mockResolvedValue({ error: { code: 'AUTH_REFRESH_FAILED', requireRelogin: true } });
+
+      await authManager.fetchUserProfile();
+
+      expect(mockAuth.logout).toHaveBeenCalled();
+      expect(mockUserDataManager.cleanupOnLogout).toHaveBeenCalled();
+    });
   });
 
   describe('Subscription Management', () => {
@@ -214,6 +227,16 @@ describe('Authentication Manager', () => {
 
       const result = await authManager.fetchSubscription();
 
+      expect(result).toEqual({ isSubscribed: false });
+    });
+
+    test('fully logs out when the subscription fetch signals a dead session (requireRelogin)', async () => {
+      mockUserDataManager.getUserProfile.mockResolvedValue(null); // force the cache-miss path
+      mockAuth.fetchUserProfile.mockResolvedValue({ error: { code: 'AUTH_REFRESH_FAILED', requireRelogin: true } });
+
+      const result = await authManager.fetchSubscription();
+
+      expect(mockAuth.logout).toHaveBeenCalled();
       expect(result).toEqual({ isSubscribed: false });
     });
   });

--- a/tests/unit/auth-manager.test.js
+++ b/tests/unit/auth-manager.test.js
@@ -350,28 +350,28 @@ describe('Authentication Manager', () => {
       expect(result).toBe(false);
     });
 
-    test('should trim local pages to the anonymous entitlement instead of wiping them', async () => {
+    test('should not modify local pages on logout, even beyond the anonymous entitlement', async () => {
+      // pages/appearance/advanced are the user's actual content, and this device may hold
+      // the only unsynced copy. Trimming/clearing them locally on logout is unrecoverable
+      // if that copy was never uploaded, so logout must leave them untouched.
       mockAuth.logout.mockResolvedValue(true);
       const premiumPages = [{ name: 'Page 1' }, { name: 'Page 2' }, { name: 'Page 3' }];
       mockConfigStore.get.mockImplementation(key => (key === 'pages' ? premiumPages : undefined));
 
       await authManager.logout();
 
-      expect(mockConfigStore.set).toHaveBeenCalledWith('pages', [{ name: 'Page 1' }]);
+      expect(mockConfigStore.set).not.toHaveBeenCalledWith('pages', expect.anything());
+      expect(mockConfigStore.set).not.toHaveBeenCalledWith('appearance', expect.anything());
+      expect(mockConfigStore.set).not.toHaveBeenCalledWith('advanced', expect.anything());
     });
 
-    test('should mark the post-logout state as synced so it is not mistaken for the next user\'s unsynced changes', async () => {
-      // Sync is disabled before pages are trimmed, so the 'pages' write never reaches
-      // cloud-sync's onDidChange handler and _sync metadata is left stale. Without
-      // markAsSynced() here, the next person to log in on this shared device would
-      // have hasUnsyncedChanges() report the leftover page as their own unsynced
-      // change, and conflict resolution could upload/merge it into their account.
+    test('should not touch sync metadata on logout since no synced data is modified', async () => {
       mockAuth.logout.mockResolvedValue(true);
       const { markAsSynced } = require('../../src/main/config');
 
       await authManager.logout();
 
-      expect(markAsSynced).toHaveBeenCalledWith(mockConfigStore);
+      expect(markAsSynced).not.toHaveBeenCalled();
     });
 
     test('should handle logout exceptions', async () => {

--- a/tests/unit/auth-manager.test.js
+++ b/tests/unit/auth-manager.test.js
@@ -395,6 +395,46 @@ describe('Authentication Manager', () => {
       const authStateCalls = mockWindows.toast.webContents.send.mock.calls.filter(call => call[0] === 'auth-state-changed');
       expect(authStateCalls).toHaveLength(0);
     });
+
+    test('aborts the login continuation (skips login-success and the authenticated config write) when logout completes while the profile fetch is still in flight', async () => {
+      // The authSequence guard originally only protected the final notifyAuthStateChange
+      // inside the background sync. The state mutations earlier in the same function —
+      // notifyLoginSuccess and the ConfigStore subscription write — ran unguarded, so a
+      // logout that completed while awaiting fetchUserProfile/getUserProfile got
+      // overwritten back to "authenticated" once the login continuation resumed.
+      const mockSyncManager = {
+        updateCloudSyncSettings: jest.fn(),
+        syncAfterLogin: jest.fn().mockResolvedValue({ success: true }),
+      };
+      authManager.setSyncManager(mockSyncManager);
+
+      mockAuth.exchangeCodeForTokenAndUpdateSubscription.mockResolvedValue({
+        success: true,
+        subscription: { active: true, plan: 'Premium' },
+      });
+
+      let resolveFetchUserProfile;
+      mockAuth.fetchUserProfile.mockImplementationOnce(
+        () =>
+          new Promise(resolve => {
+            resolveFetchUserProfile = resolve;
+          }),
+      );
+
+      const loginPromise = authManager.exchangeCodeForTokenAndUpdateSubscription('test-code');
+
+      // Log out while the login continuation is still awaiting the profile fetch.
+      await authManager.logout();
+      mockConfigStore.set.mockClear();
+      mockWindows.toast.webContents.send.mockClear();
+
+      resolveFetchUserProfile({ email: 'test@example.com' });
+      const loginResult = await loginPromise;
+
+      expect(loginResult.success).toBe(false);
+      expect(mockConfigStore.set).not.toHaveBeenCalledWith('subscription', expect.objectContaining({ isAuthenticated: true }));
+      expect(mockWindows.toast.webContents.send).not.toHaveBeenCalledWith('login-success', expect.anything());
+    });
   });
 
   describe('Logout Process', () => {

--- a/tests/unit/cloud-sync.test.js
+++ b/tests/unit/cloud-sync.test.js
@@ -630,6 +630,13 @@ describe('Cloud Sync Module', () => {
       // of preserving it via merge.
       const configModule = require('../../src/main/config');
       mockAuthManager.hasValidToken.mockResolvedValue(false);
+      // canSync() delegates the actual availability decision to apiSync.isCloudSyncEnabled
+      // (which internally calls hasValidToken in production) — that module is fully mocked
+      // here, so hasValidToken alone has no effect on canSync()'s result unless this is also
+      // set, to mirror what the real isCloudSyncEnabled returns when logged out. Without it,
+      // canSync() stays true, scheduleSync() would only be skipped because the debounce
+      // timer is never advanced — not because sync was actually blocked.
+      mockApiSync.isCloudSyncEnabled.mockResolvedValue(false);
 
       const changeHandlerCall = mockConfigStore.onDidChange.mock.calls.find(call =>
         call[0] === 'pages' && typeof call[1] === 'function'
@@ -639,6 +646,9 @@ describe('Cloud Sync Module', () => {
       await changeHandlerCall[1]([], []);
 
       expect(configModule.markAsModified).toHaveBeenCalledWith(mockConfigStore);
+      // No debounce timer should even be scheduled once sync is confirmed unavailable, so
+      // advancing well past SYNC_DEBOUNCE_MS still must not trigger an upload.
+      await jest.advanceTimersByTimeAsync(5000);
       expect(mockApiSync.uploadSettings).not.toHaveBeenCalled();
     });
 

--- a/tests/unit/cloud-sync.test.js
+++ b/tests/unit/cloud-sync.test.js
@@ -896,6 +896,38 @@ describe('Cloud Sync Module', () => {
       const uploadAfter = await cloudSync.uploadSettings();
       expect(uploadAfter.success).toBe(true);
     });
+
+    test('does not drop a change that arrives while the resolve peek download holds the sync lock', async () => {
+      // Regression: the peek download's finally only cleared state.isSyncing and never
+      // consulted state.pendingSync, so a change that arrived while server settings were
+      // being fetched for conflict analysis was silently dropped until the next periodic sync.
+      const configModule = require('../../src/main/config');
+      configModule.hasUnsyncedChanges.mockReturnValue(false);
+
+      const pagesHandler = mockConfigStore.onDidChange.mock.calls.find(call => call[0] === 'pages')[1];
+
+      let resolveDownload;
+      mockApiSync.downloadSettings.mockReturnValueOnce(
+        new Promise(resolve => {
+          resolveDownload = resolve;
+        }),
+      );
+
+      const resolvePromise = cloudSync.syncSettings('resolve');
+
+      // A change arrives while the peek download holds the sync lock.
+      await pagesHandler([], []);
+
+      resolveDownload({ success: true, data: {}, syncMetadata: { lastModifiedAt: Date.now() - 10 * 60 * 1000 } });
+      await resolvePromise;
+
+      // The change that arrived mid-peek must still be reprocessed: 1s delay, then a
+      // fresh 5s debounce, then an upload.
+      mockApiSync.uploadSettings.mockResolvedValueOnce({ success: true });
+      await jest.advanceTimersByTimeAsync(1000 + 5000);
+
+      expect(mockApiSync.uploadSettings).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('Enable/Disable Functionality', () => {

--- a/tests/unit/cloud-sync.test.js
+++ b/tests/unit/cloud-sync.test.js
@@ -399,6 +399,26 @@ describe('Cloud Sync Module', () => {
       expect(result.error).toContain('failure'); // More flexible matching
     });
 
+    test('marks synced using the uploaded snapshot rather than live ConfigStore data', async () => {
+      // A change made during the upload round-trip must not be mistaken for already
+      // being synced: markAsSynced has to hash the data that was actually sent, not
+      // whatever ConfigStore holds by the time the response comes back.
+      const configModule = require('../../src/main/config');
+      mockApiSync.uploadSettings.mockResolvedValue({ success: true });
+
+      await cloudSync.uploadSettings();
+
+      expect(configModule.markAsSynced).toHaveBeenCalledWith(
+        mockConfigStore,
+        null,
+        expect.objectContaining({
+          pages: expect.any(Array),
+          appearance: expect.any(Object),
+          advanced: expect.any(Object),
+        }),
+      );
+    });
+
     test('should call API with expected data structure', async () => {
       // Reset to fresh state for this test
       delete require.cache[require.resolve('../../src/main/cloud-sync')];
@@ -532,6 +552,35 @@ describe('Cloud Sync Module', () => {
       expect(result.error).toContain('timeout');
     });
 
+    test('refreshes dataHash via markAsSynced after applying server data with metadata', async () => {
+      // Previously only lastSyncedAt/lastModifiedAt were updated when serverMetadata was
+      // present, leaving dataHash stale so hasUnsyncedChanges() was true on every check
+      // right after a download. markAsSynced must run first to recompute it from the data
+      // that was just written, then lastModifiedAt/Device are overridden with the server's.
+      delete require.cache[require.resolve('../../src/main/cloud-sync')];
+      const freshCloudSync = require('../../src/main/cloud-sync');
+      freshCloudSync.initCloudSync(mockAuthManager, null, mockConfigStore);
+      const configModule = require('../../src/main/config');
+      configModule.markAsSynced.mockClear();
+      configModule.updateSyncMetadata.mockClear();
+
+      mockApiSync.downloadSettings.mockResolvedValue({
+        success: true,
+        data: {},
+        normalized: { pages: [{ name: 'P1', buttons: [] }], appearance: {}, advanced: {} },
+        syncMetadata: { lastModifiedAt: 123, lastModifiedDevice: 'server-device' },
+      });
+
+      const result = await freshCloudSync.downloadSettings();
+
+      expect(result.success).toBe(true);
+      expect(configModule.markAsSynced).toHaveBeenCalledWith(mockConfigStore);
+      expect(configModule.updateSyncMetadata).toHaveBeenCalledWith(
+        mockConfigStore,
+        expect.objectContaining({ lastModifiedAt: 123, lastModifiedDevice: 'server-device' }),
+      );
+    });
+
     test('should attempt to notify auth manager on sync', async () => {
       // Reset to fresh state for this test
       delete require.cache[require.resolve('../../src/main/cloud-sync')];
@@ -567,12 +616,30 @@ describe('Cloud Sync Module', () => {
       if (changeHandlerCall) {
         const handler = changeHandlerCall[1];
         const initialTimerCount = jest.getTimerCount();
-        
+
         handler([], []);
-        
+
         // Handler should potentially schedule sync operations
         expect(jest.getTimerCount()).toBeGreaterThanOrEqual(initialTimerCount);
       }
+    });
+
+    test('records markAsModified even when sync cannot run (e.g. logged out)', async () => {
+      // Without this, an offline edit's lastModifiedAt stays stale, so a later conflict
+      // check (after re-login) can pick download_server and overwrite the edit instead
+      // of preserving it via merge.
+      const configModule = require('../../src/main/config');
+      mockAuthManager.hasValidToken.mockResolvedValue(false);
+
+      const changeHandlerCall = mockConfigStore.onDidChange.mock.calls.find(call =>
+        call[0] === 'pages' && typeof call[1] === 'function'
+      );
+      expect(changeHandlerCall).toBeDefined();
+
+      await changeHandlerCall[1]([], []);
+
+      expect(configModule.markAsModified).toHaveBeenCalledWith(mockConfigStore);
+      expect(mockApiSync.uploadSettings).not.toHaveBeenCalled();
     });
   });
 
@@ -701,6 +768,38 @@ describe('Cloud Sync Module', () => {
       const result = await cloudSync.syncSettings();
 
       expect(result.success).toBe(true);
+    });
+
+    test('holds the cloud-sync lock during the resolve peek download so a concurrent upload defers instead of colliding with api/sync.js\'s own lock', async () => {
+      // api/sync.js shares one isSyncing flag between its own upload/download. Without
+      // cloud-sync.js holding its own lock for this peek (which doesn't touch ConfigStore),
+      // a debounced upload could start concurrently and fail with a spurious "Sync already
+      // in progress" from api/sync.js instead of being deferred here.
+      const configModule = require('../../src/main/config');
+      configModule.hasUnsyncedChanges.mockReturnValue(false);
+
+      let resolveDownload;
+      mockApiSync.downloadSettings.mockReturnValue(
+        new Promise(resolve => {
+          resolveDownload = resolve;
+        }),
+      );
+
+      const resolvePromise = cloudSync.syncSettings('resolve');
+
+      // While the peek download is still in flight, a concurrent upload must be deferred
+      // at the cloud-sync level, never reaching apiSync.uploadSettings.
+      const concurrentUpload = await cloudSync.uploadSettings();
+      expect(concurrentUpload.success).toBe(false);
+      expect(mockApiSync.uploadSettings).not.toHaveBeenCalled();
+
+      resolveDownload({ success: true, data: {}, syncMetadata: { lastModifiedAt: Date.now() - 10 * 60 * 1000 } });
+      await resolvePromise;
+
+      // The lock must be released afterwards so normal syncing resumes.
+      mockApiSync.uploadSettings.mockResolvedValue({ success: true });
+      const uploadAfter = await cloudSync.uploadSettings();
+      expect(uploadAfter.success).toBe(true);
     });
   });
 

--- a/tests/unit/cloud-sync.test.js
+++ b/tests/unit/cloud-sync.test.js
@@ -641,6 +641,101 @@ describe('Cloud Sync Module', () => {
       expect(configModule.markAsModified).toHaveBeenCalledWith(mockConfigStore);
       expect(mockApiSync.uploadSettings).not.toHaveBeenCalled();
     });
+
+    test('does not drop a change that arrives while a debounced upload is still in flight', async () => {
+      // Regression: uploadSettingsWithRetry's success/skipped/409/400 branches used to
+      // unconditionally clear state.pendingSync, discarding a change that arrived after
+      // the upload's snapshot was taken but before it resolved. Only the finally block
+      // should own clearing pendingSync, after acting on it.
+      const pagesHandler = mockConfigStore.onDidChange.mock.calls.find(call => call[0] === 'pages')[1];
+      const snippetsHandler = mockConfigStore.onDidChange.mock.calls.find(call => call[0] === 'snippets')[1];
+
+      let resolveFirstUpload;
+      mockApiSync.uploadSettings.mockImplementationOnce(
+        () =>
+          new Promise(resolve => {
+            resolveFirstUpload = resolve;
+          }),
+      );
+
+      await pagesHandler([], []);
+      await jest.advanceTimersByTimeAsync(5000); // debounce fires -> upload starts, now pending
+
+      expect(mockApiSync.uploadSettings).toHaveBeenCalledTimes(1);
+
+      // A second, independent change arrives while the first upload is still in flight.
+      await snippetsHandler();
+
+      // Let the in-flight upload succeed.
+      resolveFirstUpload({ success: true });
+      await Promise.resolve();
+      await Promise.resolve();
+
+      // The pending change must trigger a reprocessing (1s delay) which itself debounces
+      // another 5s before actually re-uploading.
+      await jest.advanceTimersByTimeAsync(1000 + 5000);
+
+      expect(mockApiSync.uploadSettings).toHaveBeenCalledTimes(2);
+    });
+
+    test('does not drop a change that arrives while reconcileStaleUpload (409 recovery) holds the sync lock', async () => {
+      // Regression: reconcileStaleUpload's finally only cleared state.isSyncing and never
+      // consulted state.pendingSync, so a change that arrived while it was downloading +
+      // merging + re-uploading was silently dropped until the next periodic sync.
+      mockConfigStore.get.mockImplementation(key => {
+        const mockData = {
+          pages: [{ id: 1, name: 'Test Page' }],
+          snippets: [],
+          appearance: { theme: 'dark' },
+          advanced: { autoStart: true },
+        };
+        return mockData[key] ?? {};
+      });
+
+      const pagesHandler = mockConfigStore.onDidChange.mock.calls.find(call => call[0] === 'pages')[1];
+      const snippetsHandler = mockConfigStore.onDidChange.mock.calls.find(call => call[0] === 'snippets')[1];
+
+      // First upload attempt is rejected as stale (409), which schedules reconcileStaleUpload.
+      mockApiSync.uploadSettings.mockImplementationOnce(() =>
+        Promise.resolve({ error: { code: 'HTTP_409', message: 'stale', statusCode: 409 } }),
+      );
+
+      await pagesHandler([], []);
+      await jest.advanceTimersByTimeAsync(5000); // debounce -> upload -> 409 -> reconcile scheduled in 5s
+
+      expect(mockApiSync.uploadSettings).toHaveBeenCalledTimes(1);
+
+      // reconcile's download starts here; hold it open so a change can arrive mid-reconcile.
+      let resolveDownload;
+      mockApiSync.downloadSettings.mockReturnValueOnce(
+        new Promise(resolve => {
+          resolveDownload = resolve;
+        }),
+      );
+      mockApiSync.uploadSettings.mockResolvedValueOnce({ success: true }); // reconcile's own re-upload
+
+      await jest.advanceTimersByTimeAsync(5000); // reconcile timer fires, download now pending
+
+      // A second, independent change arrives while reconciliation holds the sync lock.
+      await snippetsHandler();
+
+      resolveDownload({
+        success: true,
+        data: {},
+        normalized: { pages: [], snippets: [], appearance: {}, advanced: {} },
+      });
+      await jest.advanceTimersByTimeAsync(0);
+
+      // reconcile's own re-upload should have completed by now.
+      expect(mockApiSync.uploadSettings).toHaveBeenCalledTimes(2);
+
+      // The change that arrived mid-reconcile must still be reprocessed: 1s delay, then a
+      // fresh 5s debounce, then another upload.
+      mockApiSync.uploadSettings.mockResolvedValueOnce({ success: true });
+      await jest.advanceTimersByTimeAsync(1000 + 5000);
+
+      expect(mockApiSync.uploadSettings).toHaveBeenCalledTimes(3);
+    });
   });
 
   describe('Login Sync', () => {

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -192,5 +192,33 @@ describe('Configuration Store', () => {
       const data = { pages: [], snippets: [{ keyword: ':x', content: 'y' }], appearance: {}, advanced: {} };
       expect(generateDataHash(data)).toBe(generateDataHash({ ...data }));
     });
+
+    test('detects content changes even when array lengths are unchanged', () => {
+      // A JSON.stringify(value, arrayOfKeys) call treats the array as a property
+      // allowlist applied at every nesting level, not a sort — so nested fields
+      // like button names/shortcuts or a snippet's content would be silently
+      // stripped and two differently-edited datasets would hash identically.
+      const { generateDataHash } = require('../../src/main/config');
+      const before = {
+        pages: [{ name: 'Page 1', buttons: [{ name: 'btn1', shortcut: 'a' }] }],
+        snippets: [{ keyword: ':x', content: 'before' }],
+        appearance: { theme: 'dark' },
+        advanced: { launchAtLogin: false },
+      };
+      const after = {
+        pages: [{ name: 'Page 1', buttons: [{ name: 'btn1-renamed', shortcut: 'b' }] }],
+        snippets: [{ keyword: ':x', content: 'after' }],
+        appearance: { theme: 'light' },
+        advanced: { launchAtLogin: true },
+      };
+      expect(generateDataHash(before)).not.toBe(generateDataHash(after));
+    });
+
+    test('is independent of nested key insertion order', () => {
+      const { generateDataHash } = require('../../src/main/config');
+      const a = { pages: [], snippets: [], appearance: { theme: 'dark', accentColor: 'blue' }, advanced: {} };
+      const b = { pages: [], snippets: [], appearance: { accentColor: 'blue', theme: 'dark' }, advanced: {} };
+      expect(generateDataHash(a)).toBe(generateDataHash(b));
+    });
   });
 });

--- a/tests/unit/config.test.js
+++ b/tests/unit/config.test.js
@@ -221,4 +221,35 @@ describe('Configuration Store', () => {
       expect(generateDataHash(a)).toBe(generateDataHash(b));
     });
   });
+
+  describe('markAsSynced', () => {
+    test('hashes the provided data override instead of the live ConfigStore contents', () => {
+      // Guards against marking an upload as synced using data that changed during the
+      // network round-trip: the hash must reflect what was actually uploaded.
+      const { createConfigStore, markAsSynced, generateDataHash } = require('../../src/main/config');
+      const config = createConfigStore();
+      const liveData = { pages: [{ name: 'live-edited' }], snippets: [], appearance: {}, advanced: {} };
+      config.get.mockImplementation(key => ({ ...liveData, _sync: {} }[key]));
+
+      const uploadedSnapshot = { pages: [{ name: 'uploaded' }], snippets: [], appearance: {}, advanced: {} };
+      markAsSynced(config, null, uploadedSnapshot);
+
+      const syncCall = config.set.mock.calls.find(call => call[0] === '_sync');
+      expect(syncCall).toBeDefined();
+      expect(syncCall[1].dataHash).toBe(generateDataHash(uploadedSnapshot));
+      expect(syncCall[1].dataHash).not.toBe(generateDataHash(liveData));
+    });
+
+    test('falls back to the live ConfigStore contents when no override is given', () => {
+      const { createConfigStore, markAsSynced, generateDataHash } = require('../../src/main/config');
+      const config = createConfigStore();
+      const liveData = { pages: [{ name: 'live' }], snippets: [], appearance: {}, advanced: {} };
+      config.get.mockImplementation(key => ({ ...liveData, _sync: {} }[key]));
+
+      markAsSynced(config);
+
+      const syncCall = config.set.mock.calls.find(call => call[0] === '_sync');
+      expect(syncCall[1].dataHash).toBe(generateDataHash(liveData));
+    });
+  });
 });

--- a/tests/unit/main-auth.test.js
+++ b/tests/unit/main-auth.test.js
@@ -359,6 +359,27 @@ describe('Main Auth Module (P0)', () => {
       expect(result.success).toBe(false);
       expect(mockConfig.set).not.toHaveBeenCalledWith('subscription', expect.objectContaining({ isAuthenticated: true }));
     });
+
+    test('reports failure instead of writing an authenticated config when the post-login subscription fetch itself fails', async () => {
+      // Regression: fetchSubscription() returns the error-shaped profileData as-is on
+      // failure (not a subscription object). refreshSubscriptionSettings() previously
+      // passed that straight to updatePageGroupSettings(), which unconditionally writes
+      // isAuthenticated: true — silently reporting login success on a failed profile fetch.
+      mockApiAuth.exchangeCodeForToken.mockResolvedValue({
+        success: true,
+        access_token: 'new-access-token',
+        refresh_token: 'new-refresh-token',
+        expires_in: 3600,
+      });
+      mockApiAuth.fetchUserProfile.mockResolvedValue({
+        error: { code: 'PROFILE_FETCH_FAILED', message: 'Network error' },
+      });
+
+      const result = await auth.exchangeCodeForTokenAndUpdateSubscription('test-code');
+
+      expect(result.success).toBe(false);
+      expect(mockConfig.set).not.toHaveBeenCalledWith('subscription', expect.objectContaining({ isAuthenticated: true }));
+    });
   });
 
   describe('Token Management', () => {

--- a/tests/unit/main-auth.test.js
+++ b/tests/unit/main-auth.test.js
@@ -426,6 +426,106 @@ describe('Main Auth Module (P0)', () => {
       expect(secondResult.success).toBe(true);
       expect(secondResult.code).not.toBe('REFRESH_THROTTLED');
     });
+
+    test('concurrent refreshAccessToken calls share the in-flight promise instead of one being throttled', async () => {
+      // The dedup check (isRefreshing && refreshPromise) must run before the throttle
+      // window check, or a second caller arriving while a refresh is already in flight
+      // gets misrouted into REFRESH_THROTTLED instead of sharing the same promise.
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readFileSync.mockReturnValue(JSON.stringify({
+        'auth-token': 'expired-token',
+        'refresh-token': 'test-refresh-token',
+        'token-expires-at': Date.now() - 3600000,
+      }));
+
+      let resolveRefresh;
+      // mockImplementationOnce (not mockReturnValue/mockResolvedValue): the latter would
+      // permanently pin refreshAccessToken to this one already-settled Promise instance,
+      // leaking into every later test that calls it.
+      mockApiAuth.refreshAccessToken.mockImplementationOnce(
+        () =>
+          new Promise(resolve => {
+            resolveRefresh = resolve;
+          }),
+      );
+
+      const firstCall = auth.refreshAccessToken();
+      const secondCall = auth.refreshAccessToken();
+
+      // refreshAccessToken awaits isTokenExpired() (itself a chain of awaits) before
+      // calling apiAuth.refreshAccessToken, so let all pending microtasks flush before
+      // resolveRefresh is guaranteed to have been assigned.
+      await new Promise(resolve => setImmediate(resolve));
+
+      resolveRefresh({ success: true, access_token: 'refreshed-token', expires_in: 3600 });
+
+      const [firstResult, secondResult] = await Promise.all([firstCall, secondCall]);
+
+      expect(mockApiAuth.refreshAccessToken).toHaveBeenCalledTimes(1);
+      expect(firstResult.success).toBe(true);
+      expect(secondResult.success).toBe(true);
+      expect(secondResult.code).not.toBe('REFRESH_THROTTLED');
+    });
+
+    test('hasValidToken triggers the registered session-expired handler on a dead session', async () => {
+      // hasValidToken refreshes internally without going through auth-manager's own
+      // requireRelogin checks, so it must still notify the app of a dead session instead
+      // of silently leaving the UI in a stale "logged in" state.
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readFileSync.mockReturnValue(JSON.stringify({
+        'auth-token': 'expired-token',
+        'refresh-token': 'dead-refresh-token',
+        'token-expires-at': Date.now() - 3600000,
+      }));
+
+      mockApiAuth.refreshAccessToken.mockResolvedValue({
+        success: false,
+        code: 'SESSION_EXPIRED',
+        requireRelogin: true,
+      });
+
+      const handler = jest.fn();
+      auth.setSessionExpiredHandler(handler);
+
+      const isValid = await auth.hasValidToken();
+      await Promise.resolve();
+
+      expect(isValid).toBe(false);
+      expect(handler).toHaveBeenCalled();
+    });
+
+    test('logout prevents an in-flight refresh from resurrecting the deleted token file', async () => {
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readFileSync.mockReturnValue(JSON.stringify({
+        'auth-token': 'expired-token',
+        'refresh-token': 'test-refresh-token',
+        'token-expires-at': Date.now() - 3600000,
+      }));
+
+      let resolveRefresh;
+      // mockImplementationOnce so this settled Promise instance doesn't leak into later
+      // tests the way a permanent mockReturnValue/mockResolvedValue would.
+      mockApiAuth.refreshAccessToken.mockImplementationOnce(
+        () =>
+          new Promise(resolve => {
+            resolveRefresh = resolve;
+          }),
+      );
+
+      const refreshPromise = auth.refreshAccessToken();
+
+      // logout() runs to completion while the refresh above is still in flight.
+      mockFs.writeFileSync.mockClear();
+      await auth.logout();
+
+      // The refresh completes afterwards with a rotated token.
+      resolveRefresh({ success: true, access_token: 'new-token', refresh_token: 'new-refresh-token', expires_in: 3600 });
+      const refreshResult = await refreshPromise;
+
+      expect(refreshResult.success).toBe(false);
+      // The logout-deleted token file must not be resurrected by the late refresh response.
+      expect(mockFs.writeFileSync).not.toHaveBeenCalled();
+    });
   });
 
   describe('User Profile Management', () => {

--- a/tests/unit/main-auth.test.js
+++ b/tests/unit/main-auth.test.js
@@ -382,6 +382,37 @@ describe('Main Auth Module (P0)', () => {
       expect(result.success).toBe(false);
       expect(result.error).toContain('Refresh failed');
     });
+
+    test('does not lock out retries for the cooldown window after a failed refresh', async () => {
+      // A single transient failure (e.g. a network blip) must not block every
+      // subsequent refresh attempt for the full 5-minute cooldown window.
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readFileSync.mockReturnValue(JSON.stringify({
+        'auth-token': 'expired-token',
+        'refresh-token': 'test-refresh-token',
+        'token-expires-at': Date.now() - 3600000,
+      }));
+
+      mockApiAuth.refreshAccessToken.mockResolvedValueOnce({
+        success: false,
+        error: 'network error',
+      });
+
+      const firstResult = await auth.refreshAccessToken();
+      expect(firstResult.success).toBe(false);
+
+      mockApiAuth.refreshAccessToken.mockResolvedValueOnce({
+        success: true,
+        access_token: 'refreshed-token',
+        expires_in: 3600,
+      });
+
+      const secondResult = await auth.refreshAccessToken();
+
+      expect(mockApiAuth.refreshAccessToken).toHaveBeenCalledTimes(2);
+      expect(secondResult.success).toBe(true);
+      expect(secondResult.code).not.toBe('REFRESH_THROTTLED');
+    });
   });
 
   describe('User Profile Management', () => {

--- a/tests/unit/main-auth.test.js
+++ b/tests/unit/main-auth.test.js
@@ -237,6 +237,56 @@ describe('Main Auth Module (P0)', () => {
       expect(JSON.stringify(result)).not.toContain('internal_debug_info');
     });
 
+    test('discards issued tokens when logout completes while the code exchange is still in flight', async () => {
+      // Regression: only refreshAccessToken had the isLoggingOut/logoutGeneration guards.
+      // exchangeCodeForToken's own storeTokens call was unguarded, so a logout completing
+      // while the token endpoint request was in flight got its deleted token file
+      // resurrected by the login that was already underway.
+      let resolveExchange;
+      mockApiAuth.exchangeCodeForToken.mockImplementationOnce(
+        () =>
+          new Promise(resolve => {
+            resolveExchange = resolve;
+          }),
+      );
+
+      const exchangePromise = auth.exchangeCodeForToken('test-code');
+
+      mockFs.writeFileSync.mockClear();
+      await auth.logout();
+
+      resolveExchange({
+        success: true,
+        access_token: 'new-token',
+        refresh_token: 'new-refresh-token',
+        expires_in: 3600,
+      });
+      const result = await exchangePromise;
+
+      expect(result.success).toBe(false);
+      expect(mockFs.writeFileSync).not.toHaveBeenCalled();
+    });
+
+    test('blocks a code exchange attempted while logout is in progress, before it ever contacts the server', async () => {
+      let resolveRevoke;
+      mockApiAuth.revokeToken.mockImplementationOnce(
+        () =>
+          new Promise(resolve => {
+            resolveRevoke = resolve;
+          }),
+      );
+
+      const logoutPromise = auth.logout();
+
+      const result = await auth.exchangeCodeForToken('test-code');
+
+      expect(result.success).toBe(false);
+      expect(mockApiAuth.exchangeCodeForToken).not.toHaveBeenCalled();
+
+      resolveRevoke({ success: true });
+      await logoutPromise;
+    });
+
     test('should handle auth redirect URLs', async () => {
       const authUrl = 'toast-app://auth?code=test-code&state=test-state';
 
@@ -266,6 +316,48 @@ describe('Main Auth Module (P0)', () => {
 
       expect(result).toEqual({ success: true });
       expect(mockShell.openExternal).toHaveBeenCalled();
+    });
+
+    test('discards the subscription update (no authenticated config write) when logout completes while the post-login subscription fetch is still in flight', async () => {
+      // Regression: exchangeCodeForToken's own storeTokens call is guarded, but the
+      // subsequent fetchSubscription()+updatePageGroupSettings() write in
+      // exchangeCodeForTokenAndUpdateSubscription was not — a logout completing during
+      // that fetch got its anonymous config write overwritten back to authenticated.
+      mockApiAuth.exchangeCodeForToken.mockResolvedValue({
+        success: true,
+        access_token: 'new-access-token',
+        refresh_token: 'new-refresh-token',
+        expires_in: 3600,
+      });
+
+      let resolveProfile;
+      mockApiAuth.fetchUserProfile.mockImplementationOnce(
+        () =>
+          new Promise(resolve => {
+            resolveProfile = resolve;
+          }),
+      );
+
+      const exchangePromise = auth.exchangeCodeForTokenAndUpdateSubscription('test-code');
+
+      // Let the code exchange (its own separate await chain) complete and the
+      // subscription fetch reach the pending apiAuth.fetchUserProfile() call above,
+      // before logging out — otherwise logout could race ahead of the exchange itself.
+      await new Promise(resolve => setImmediate(resolve));
+      await new Promise(resolve => setImmediate(resolve));
+
+      mockConfig.set.mockClear();
+      await auth.logout();
+
+      resolveProfile({
+        id: 'user123',
+        email: 'test@example.com',
+        subscription: { active: true, plan: 'premium' },
+      });
+      const result = await exchangePromise;
+
+      expect(result.success).toBe(false);
+      expect(mockConfig.set).not.toHaveBeenCalledWith('subscription', expect.objectContaining({ isAuthenticated: true }));
     });
   });
 
@@ -525,6 +617,37 @@ describe('Main Auth Module (P0)', () => {
       expect(refreshResult.success).toBe(false);
       // The logout-deleted token file must not be resurrected by the late refresh response.
       expect(mockFs.writeFileSync).not.toHaveBeenCalled();
+    });
+
+    test('blocks a new refresh attempt started while logout is in progress, before it ever contacts the server', async () => {
+      // A refresh that starts mid-logout must be stopped before making a network call at
+      // all — even a result that's later discarded would still rotate the refresh token
+      // server-side, leaving an unrevoked token nobody has a record of.
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.readFileSync.mockReturnValue(JSON.stringify({
+        'auth-token': 'expired-token',
+        'refresh-token': 'test-refresh-token',
+        'token-expires-at': Date.now() - 3600000,
+      }));
+
+      let resolveRevoke;
+      mockApiAuth.revokeToken.mockImplementationOnce(
+        () =>
+          new Promise(resolve => {
+            resolveRevoke = resolve;
+          }),
+      );
+
+      const logoutPromise = auth.logout(); // starts, suspended awaiting revokeToken
+
+      const refreshResult = await auth.refreshAccessToken();
+
+      expect(refreshResult.success).toBe(false);
+      expect(refreshResult.code).toBe('LOGOUT_IN_PROGRESS');
+      expect(mockApiAuth.refreshAccessToken).not.toHaveBeenCalled();
+
+      resolveRevoke({ success: true });
+      await logoutPromise;
     });
   });
 

--- a/tests/unit/main-auth.test.js
+++ b/tests/unit/main-auth.test.js
@@ -254,6 +254,19 @@ describe('Main Auth Module (P0)', () => {
       expect(result.success).toBe(false);
       expect(result.error).toContain('Invalid URL');
     });
+
+    test('reload_auth deep link returns an object result when starting login for an unauthenticated user', async () => {
+      // initiateLogin() resolves to a bare boolean, but handleAuthRedirect's callers
+      // (e.g. src/index.js) check result.success — a bare `true` would read as failure.
+      mockClient.getAccessToken.mockReturnValue(null);
+      mockFs.existsSync.mockReturnValue(false); // no stored token file either
+
+      const redirectUrl = 'toast-app://auth?action=reload_auth&token=abc123&userId=user1';
+      const result = await auth.handleAuthRedirect(redirectUrl);
+
+      expect(result).toEqual({ success: true });
+      expect(mockShell.openExternal).toHaveBeenCalled();
+    });
   });
 
   describe('Token Management', () => {

--- a/tests/unit/text-expander/index.test.js
+++ b/tests/unit/text-expander/index.test.js
@@ -119,6 +119,13 @@ describe('Text Expander (I/O layer)', () => {
   test('preserves a non-text clipboard (e.g. a copied image) across a snippet expansion', () => {
     clipboard.availableFormats.mockReturnValue(['image/png']);
     clipboard.readImage.mockReturnValue({ isEmpty: () => false });
+    // Writing the snippet content actually replaces clipboard contents with that text —
+    // mirror that so the restore-time "does the clipboard still hold what we wrote" check
+    // (which reads availableFormats/readText) sees it instead of the stale image mock.
+    clipboard.writeText.mockImplementation(text => {
+      clipboard.availableFormats.mockReturnValue(['text/plain']);
+      clipboard.readText.mockReturnValue(text);
+    });
 
     typeKeyword();
 
@@ -134,11 +141,50 @@ describe('Text Expander (I/O layer)', () => {
 
   test('clears the clipboard on restore when it was empty beforehand', () => {
     clipboard.availableFormats.mockReturnValue([]);
+    // See the previous test: writing the snippet content actually replaces clipboard
+    // contents, so the restore-time check must see it instead of the stale empty mock.
+    clipboard.writeText.mockImplementation(text => {
+      clipboard.availableFormats.mockReturnValue(['text/plain']);
+      clipboard.readText.mockReturnValue(text);
+    });
 
     typeKeyword();
     jest.advanceTimersByTime(300);
 
     expect(clipboard.clear).toHaveBeenCalled();
+  });
+
+  test('does not restore the previous clipboard if the user copied something else during the paste', () => {
+    typeKeyword();
+    expect(clipboard.writeText).toHaveBeenCalledWith('hello there');
+
+    // Before the restore delay elapses, the user copies something new.
+    clipboard.readText.mockReturnValue('user copied this');
+
+    jest.advanceTimersByTime(300);
+
+    // Restoring now would clobber what the user just copied.
+    expect(clipboard.write).not.toHaveBeenCalled();
+    expect(clipboard.clear).not.toHaveBeenCalled();
+  });
+
+  test('does not restore a snapshotted secret onto the clipboard after an external auto-clear', () => {
+    // Simulate having copied a password just before the snippet trigger: the pre-paste
+    // snapshot captured it.
+    clipboard.readText.mockReturnValue('super-secret-password');
+
+    typeKeyword();
+    expect(clipboard.writeText).toHaveBeenCalledWith('hello there');
+
+    // Before the restore delay elapses, an external tool (e.g. a password manager's
+    // auto-clear) wipes the clipboard.
+    clipboard.availableFormats.mockReturnValue([]);
+
+    jest.advanceTimersByTime(300);
+
+    // Restoring now would re-expose the password the auto-clear had just wiped.
+    expect(clipboard.write).not.toHaveBeenCalled();
+    expect(clipboard.clear).not.toHaveBeenCalled();
   });
 
   test('resets the match buffer when replacement throws, preventing a re-trigger loop', () => {

--- a/tests/unit/text-expander/index.test.js
+++ b/tests/unit/text-expander/index.test.js
@@ -168,6 +168,27 @@ describe('Text Expander (I/O layer)', () => {
     expect(clipboard.clear).not.toHaveBeenCalled();
   });
 
+  test('does not crash and still resets injecting when the post-paste clipboard check throws', () => {
+    // clipboard.availableFormats()/readText() here were unguarded by a catch (unlike
+    // snapshotClipboard/restoreClipboard, which both have their own). An exception from
+    // either would propagate out of the setTimeout callback as an uncaught exception.
+    clipboard.availableFormats.mockImplementation(() => {
+      throw new Error('clipboard unavailable');
+    });
+
+    typeKeyword();
+
+    expect(() => jest.advanceTimersByTime(300)).not.toThrow();
+    expect(clipboard.write).not.toHaveBeenCalled();
+
+    // injecting must still be reset so subsequent keystrokes aren't ignored forever.
+    clipboard.availableFormats.mockReturnValue(['text/plain']);
+    const onKeydown = getRegisteredHandler('keydown');
+    onKeydown(keyEvent(H_KEYCODE));
+    onKeydown(keyEvent(I_KEYCODE));
+    expect(clipboard.writeText).toHaveBeenCalledTimes(2); // once per typeKeyword() trigger
+  });
+
   test('does not restore a snapshotted secret onto the clipboard after an external auto-clear', () => {
     // Simulate having copied a password just before the snippet trigger: the pre-paste
     // snapshot captured it.

--- a/tests/unit/text-expander/matcher.test.js
+++ b/tests/unit/text-expander/matcher.test.js
@@ -283,6 +283,16 @@ describe('Text Expander Matcher', () => {
       expect(result.errors.join(' ')).toMatch(/conflicts/);
     });
 
+    test('rejects a prefix-colliding keyword (typing the longer one fires the shorter one first)', () => {
+      // ";sig" is a prefix, not a suffix, of ";signature" — endsWith alone misses this.
+      // While typing ";signature", the buffer passes through "...;sig", which would fire
+      // ";sig" before the rest of ";signature" is ever entered.
+      const existing = [{ id: '1', keyword: ';sig' }];
+      const result = validateSnippet({ id: '2', keyword: ';signature', content: 'x' }, existing);
+      expect(result.valid).toBe(false);
+      expect(result.errors.join(' ')).toMatch(/conflicts/);
+    });
+
     test('excludes self by id when re-validating an edit', () => {
       const existing = [{ id: '1', keyword: ':email' }];
       const result = validateSnippet({ id: '1', keyword: ':email', content: 'updated' }, existing);


### PR DESCRIPTION
## Summary
- OAuth 로그인/로그아웃과 클라우드 동기화 사이에서 발생할 수 있는 여러 레이스 컨디션을 닫고, 로그아웃 시 사용자 콘텐츠(pages/appearance/advanced)가 삭제되지 않도록 함
- 로그아웃 도중 진행 중이던 토큰 발급/리프레시가 완료되어 방금 삭제한 세션을 되살리는 문제, 동기화 중 도착한 변경사항이 유실되는 문제, 해시 불안정성으로 인한 오탐 등을 수정

## Changes
- **auth.js**: `isLoggingOut` 플래그와 `logoutGeneration` 카운터로 로그아웃과 동시에 진행 중인 code exchange/token refresh가 서버에서 이미 폐기된 세션을 되살리지 못하도록 차단. `refreshSubscriptionSettings()` 헬퍼로 fetchSubscription 도중 로그아웃이 끼어들 경우 ConfigStore를 되돌리지 않게 함. 리프레시 실패 시 쿨다운을 즉시 해제해 다음 시도가 막히지 않도록 함. `sessionExpiredHandler` 콜백을 추가해 `hasValidToken`의 자동 리프레시 경로에서도 SESSION_EXPIRED를 앱 레벨 로그아웃으로 연결
- **auth-manager.js**: `authSequence` 카운터로 로그인 진행 중 로그아웃(또는 더 최신 로그인)이 발생하면 stale한 로그인 완료 알림을 보내지 않도록 함. 로그아웃 시 `pages`/`appearance`/`advanced`를 더 이상 초기화하지 않음(동기화되지 않은 유일한 사본일 수 있어 삭제 시 복구 불가) — subscription만 anonymous로 리셋. `fetchUserProfile`/`fetchSubscription`이 `requireRelogin` 에러를 감지하면 전체 로그아웃을 실행하도록 함
- **cloud-sync.js**: sync 진행 중 도착한 변경사항을 `pendingSync`로 표시만 하고 버리던 것을 `reprocessPendingSync()`로 통합해 모든 완료 경로(성공/실패/스킵/재시도 초과)에서 누락 없이 재스케줄. `markAsSynced`에 업로드 시점 스냅샷을 전달해 네트워크 왕복 중 도착한 편집이 "이미 동기화됨"으로 오인되지 않게 함. conflict resolution(`syncSettings`)이 `state.isSyncing` 락을 획득하도록 해 동시 업로드가 스퓨리어스하게 실패하는 것을 방지
- **config.js**: `JSON.stringify(data, Object.keys(data).sort())`가 중첩 객체 키를 조용히 제거하던 버그를 `stableStringify()`로 교체해 `generateDataHash`가 실제 콘텐츠 변경을 정확히 감지하도록 수정
- **api/client.js**: 리프레시 쿨다운 윈도우 중에도 곧바로 미인증 처리하지 않고 현재 토큰으로 재시도(동시 요청이 이미 리프레시했을 수 있음). 리프레시 실패 시 `requireRelogin` 여부로 분기해 일시적 오류(네트워크/서버 에러)는 기존 토큰을 유지, 실제로 죽은 세션만 로그아웃
- **api/auth.js**: OAuth `state` 파라미터를 검증 후 소비(consume)해 리다이렉트 재생(replay) 공격을 방지
- **text-expander/index.js**: 스니펫 확장 후 클립보드 복원 전, 클립보드가 여전히 우리가 넣은 값을 담고 있는지 확인 — 사용자가 그 사이 다른 걸 복사했거나 외부 도구(비밀번호 관리자 등)가 클립보드를 지웠다면 덮어쓰지 않음
- **text-expander/matcher.js**: 키워드 간 접두사(prefix) 충돌도 접미사(suffix) 충돌과 동일하게 검증 — 긴 키워드를 입력하는 도중 버퍼가 짧은 키워드로 끝나는 상태를 지나가면서 먼저 트리거되는 모호성을 방지

## Test Plan
- [x] `npm run lint` — 0 errors (기존 경고 16건은 이번 변경과 무관한 파일)
- [x] `npm run test` — 38 suites / 1102 tests 전체 통과 (신규 회귀 테스트 포함: client, auth-manager, cloud-sync, config, main-auth, text-expander)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 로그인 및 로그아웃 과정의 동시 처리 안정성이 향상되어, 오래된 인증 정보가 복원되거나 최신 상태를 덮어쓰는 문제가 줄었습니다.
  * 세션 만료와 일시적인 인증 오류를 구분해 불필요한 재로그인을 줄이고, 필요한 경우 앱이 자동으로 안전하게 로그아웃됩니다.
  * 클라우드 동기화 중 발생한 추가 변경 사항이 누락되지 않고 후속 동기화로 처리됩니다.
  * 동기화 충돌 및 네트워크 지연 상황에서 설정 상태가 더욱 정확하게 유지됩니다.
  * 스니펫 키워드가 유사할 때 충돌을 안내하고, 붙여넣기 후 사용자의 클립보드 내용을 안전하게 보호합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->